### PR TITLE
chore: replace lru with s3fifo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,12 +10,6 @@ checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -398,16 +381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hashbrown"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,15 +501,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "lru"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
-dependencies = [
- "hashbrown",
-]
 
 [[package]]
 name = "memchr"
@@ -898,7 +862,6 @@ dependencies = [
  "flume",
  "futures-lite",
  "jemallocator",
- "lru",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
@@ -941,12 +904,6 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 crc32fast = "1.3.2"
 crossbeam = "0.8.2"
-lru = "0.12.0"
 chrono = "0.4.31"
 crossbeam-channel = "0.5.8"
 parking_lot = "0.12.1"

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -390,7 +390,7 @@ mod tests {
         let a = AOL::open(temp_dir.path(), &LogOptions::default()).expect("should create aol");
 
         // Create a reader for the AOL
-        let r = Reader::new_from(a, 0, 100).unwrap();
+        let r = Reader::new_from(a, 0, 10000).unwrap();
         let mut txr = TxReader::new(r).unwrap();
 
         // Read and assert the two transaction records from the reader

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,135 @@
 pub mod index;
 pub mod kv;
 pub mod log;
+
+use std::cmp::min;
+use std::collections::VecDeque;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering::SeqCst;
+
+const MAX_FREQUENCY_LIMIT: u8 = 3;
+
+struct Entry<K, V> {
+    key: K,
+    value: V,
+    freq: AtomicU8,
+}
+
+impl<K, V> Entry<K, V> {
+    pub fn new(key: K, value: V) -> Self {
+        Self {
+            key,
+            value,
+            freq: AtomicU8::new(0),
+        }
+    }
+}
+
+pub struct Cache<K, V>
+where
+    K: PartialEq,
+{
+    min_eviction_size: usize,
+    max_cache_size: usize,
+    small: VecDeque<Entry<K, V>>,
+    main: VecDeque<Entry<K, V>>,
+    ghost: VecDeque<K>,
+}
+
+impl<K, V> Cache<K, V>
+where
+    K: PartialEq,
+{
+    pub fn new(cache_size: usize) -> Self {
+        assert!(cache_size >= 10);
+        let min_eviction_size = cache_size / 10;
+
+        Self {
+            min_eviction_size,
+            max_cache_size: cache_size,
+            small: VecDeque::with_capacity(min_eviction_size),
+            main: VecDeque::with_capacity(cache_size),
+            ghost: VecDeque::with_capacity(cache_size),
+        }
+    }
+
+    pub fn read(&self, key: &K) -> Option<&V> {
+        if let Some(entry) = self
+            .small
+            .iter()
+            .chain(self.main.iter())
+            .find(|e| &e.key == key)
+        {
+            let freq = min(entry.freq.load(SeqCst) + 1, MAX_FREQUENCY_LIMIT);
+            entry.freq.store(freq, SeqCst);
+            Some(&entry.value)
+        } else {
+            None
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.ensure_free();
+
+        if self.ghost.contains(&key) {
+            let entry = Entry::new(key, value);
+            self.main.push_front(entry);
+        } else {
+            let entry = Entry::new(key, value);
+            self.small.push_front(entry);
+        }
+    }
+
+    fn insert_m(&mut self, tail: Entry<K, V>) {
+        self.main.push_front(tail);
+        if self.main.len() >= self.max_cache_size {
+            self.evict_m();
+        }
+    }
+
+    fn insert_g(&mut self, tail: Entry<K, V>) {
+        if self.ghost.len() >= self.max_cache_size {
+            self.ghost.pop_back();
+        }
+        self.ghost.push_front(tail.key);
+    }
+
+    fn ensure_free(&mut self) {
+        while self.small.len() + self.main.len() >= self.max_cache_size {
+            if self.small.len() >= self.min_eviction_size {
+                self.evict_s();
+            } else {
+                self.evict_m();
+            }
+        }
+    }
+
+    fn evict_m(&mut self) {
+        let mut evicted = false;
+        while !evicted && self.main.len() > 0 {
+            if let Some(tail) = self.main.pop_back() {
+                let freq = tail.freq.load(SeqCst);
+                if freq > 0 {
+                    tail.freq.store(freq - 1, SeqCst);
+                    self.main.push_front(tail);
+                } else {
+                    evicted = true;
+                }
+            }
+        }
+    }
+
+    fn evict_s(&mut self) {
+        let mut evicted = false;
+        while !evicted && self.small.len() > 0 {
+            if let Some(tail) = self.small.pop_back() {
+                if tail.freq.load(SeqCst) > 1 {
+                    self.insert_m(tail);
+                } else {
+                    self.insert_g(tail);
+                    evicted = false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## S3-FIFO Cache Eviction Policy Implementation

This PR adds an experimental implementation of the S3-FIFO cache eviction policy based on the research paper "FIFO Queues are ALL You Need for Cache Eviction" by Juncheng Yang, et al. ([Paper Link](https://jasony.me/publication/sosp23-s3fifo.pdf)).
