### PR TITLE
Make store async

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,28 @@
+name: Release crate
+
+run-name: "Release crate"
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish-crate:
+    name: Publish crate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Temporary Items
 /docker/
 /.direnv/
 /testdata/
+/example/
 
 # -----------------------------------
 # Specific

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,6 @@ Temporary Items
 /bin/
 /docker/
 /.direnv/
-/testdata/
-/example/
 
 # -----------------------------------
 # Specific

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools",
  "num-traits",
@@ -510,6 +511,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +361,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -481,6 +519,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1020,6 +1068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1131,7 @@ dependencies = [
  "nanoid",
  "parking_lot",
  "rand 0.8.5",
+ "sha2",
  "tempdir",
  "tokio",
 ]
@@ -1136,6 +1196,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,16 +72,196 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.0.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-executor",
+ "async-io 2.3.1",
+ "async-lock 3.3.0",
+ "blocking",
+ "futures-lite 2.0.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.0.0",
+ "parking",
+ "polling 3.3.2",
+ "rustix 0.38.28",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -93,16 +288,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.0.0",
+ "piper",
+ "tracing",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "caches"
@@ -127,7 +355,17 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -178,6 +416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +450,27 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "comfy-table"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -321,6 +591,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot 0.12.1",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +636,33 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -364,6 +693,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,16 +715,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.29"
+name = "futures"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -403,10 +778,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.29"
+name = "futures-lite"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9c1155db57329dca6d018b61e76b1488ce9a2e5e44028cac420a5898f4fcef63"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "getrandom"
@@ -418,6 +852,30 @@ dependencies = [
  "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
  "wasm-bindgen",
 ]
 
@@ -436,6 +894,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -476,13 +940,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -522,6 +997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,16 +1015,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "lmdb-rkv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "lmdb-rkv-sys",
+]
+
+[[package]]
+name = "lmdb-rkv-sys"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "lock_api"
@@ -557,6 +1128,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -568,10 +1142,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "memoffset"
@@ -580,6 +1174,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -601,12 +1221,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -629,12 +1289,37 @@ checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -645,16 +1330,45 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "plotters"
@@ -685,10 +1399,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.28",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -802,6 +1556,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72623e6275cd430215b741f41ebda34db93a13ebde253f908b70871c46afc5ba"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +1621,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,9 +1665,15 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -875,6 +1689,26 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "sanakirja"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766699f1bb95f2e358c1ec0945da82b40097ec29a3a61636833f5ff27071c392"
+dependencies = [
+ "fs2",
+ "log",
+ "memmap",
+ "parking_lot 0.11.2",
+ "sanakirja-core",
+ "thiserror",
+]
+
+[[package]]
+name = "sanakirja-core"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18ebf28e53f067c2867f2cbae572f5e5320c1074ad2f9e6ed309df22277de6"
 
 [[package]]
 name = "scopeguard"
@@ -914,10 +1748,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "spin"
@@ -929,28 +1823,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "surrealkv"
 version = "0.1.0"
 dependencies = [
+ "async-channel 2.1.1",
+ "async-std",
  "async-task",
  "bytes",
  "caches",
  "chrono",
+ "comfy-table",
  "crc32fast",
  "criterion",
  "crossbeam",
  "crossbeam-channel",
+ "ctrlc",
  "fastrand 2.0.1",
  "flume",
- "futures-lite",
+ "futures",
+ "futures-lite 1.13.0",
  "hashbrown",
  "jemallocator",
+ "libc",
+ "lmdb-rkv",
  "lru",
  "nanoid",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "rand 0.8.5",
+ "redb",
+ "rocksdb",
+ "sanakirja",
+ "sled",
  "tempdir",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -981,6 +1907,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand 2.0.1",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.28",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,10 +1950,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot 0.12.1",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.5.5",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "value-bag"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1047,6 +2070,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1287,4 +2322,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.0.0",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
@@ -120,7 +120,7 @@ dependencies = [
  "async-io 2.3.1",
  "async-lock 3.3.0",
  "blocking",
- "futures-lite 2.0.0",
+ "futures-lite 2.2.0",
  "once_cell",
 ]
 
@@ -154,9 +154,9 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.0.0",
+ "futures-lite 2.2.0",
  "parking",
- "polling 3.3.2",
+ "polling 3.4.0",
  "rustix 0.38.28",
  "slab",
  "tracing",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.4.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "atomic-waker"
@@ -265,7 +265,7 @@ dependencies = [
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.0.0",
+ "futures-lite 2.2.0",
  "piper",
  "tracing",
 ]
@@ -627,17 +627,15 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1155db57329dca6d018b61e76b1488ce9a2e5e44028cac420a5898f4fcef63"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
- "waker-fn",
 ]
 
 [[package]]
@@ -971,9 +969,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parking"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -1067,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
+checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -1487,9 +1485,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -390,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,9 +685,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lru"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
 dependencies = [
  "hashbrown",
 ]
@@ -851,6 +858,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c20af3800cee5134b79a3bd4a3d4b583c16ccfa5f53338f46400851a5b3819"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1130,6 +1149,7 @@ dependencies = [
  "lru",
  "nanoid",
  "parking_lot",
+ "quick_cache",
  "rand 0.8.5",
  "sha2",
  "tempdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,153 +73,16 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.3",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "async-executor"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
-dependencies = [
- "async-lock 3.3.0",
- "async-task",
- "concurrent-queue",
- "fastrand 2.0.1",
- "futures-lite 2.2.0",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.1.1",
- "async-executor",
- "async-io 2.3.1",
- "async-lock 3.3.0",
- "blocking",
- "futures-lite 2.2.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
-dependencies = [
- "async-lock 3.3.0",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.2.0",
- "parking",
- "polling 3.4.0",
- "rustix 0.38.28",
- "slab",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
-dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 1.13.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -253,22 +116,6 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "blocking"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
-dependencies = [
- "async-channel 2.1.1",
- "async-lock 3.3.0",
- "async-task",
- "fastrand 2.0.1",
- "futures-io",
- "futures-lite 2.2.0",
- "piper",
- "tracing",
-]
 
 [[package]]
 name = "bumpalo"
@@ -516,12 +363,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -537,17 +378,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.3",
+ "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -611,34 +443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
-dependencies = [
- "fastrand 2.0.1",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,18 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,33 +546,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.28",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -829,25 +601,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -870,9 +627,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -1009,17 +763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
-dependencies = [
- "atomic-waker",
- "fastrand 2.0.1",
- "futures-io",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,36 +788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "pin-project-lite",
- "rustix 0.38.28",
- "tracing",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1243,20 +956,6 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
@@ -1264,7 +963,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -1346,16 +1045,6 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -1368,15 +1057,14 @@ dependencies = [
 name = "surrealkv"
 version = "0.1.0"
 dependencies = [
- "async-channel 2.1.1",
- "async-std",
+ "async-channel",
  "bytes",
  "chrono",
  "crc32fast",
  "criterion",
  "crossbeam",
  "crossbeam-channel",
- "fastrand 2.0.1",
+ "fastrand",
  "futures",
  "hashbrown",
  "jemallocator",
@@ -1433,7 +1121,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -1450,44 +1138,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
-name = "value-bag"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -1528,18 +1188,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,27 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.65.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,18 +253,6 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "blocking"
@@ -310,38 +277,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "caches"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c952ebd9e8c333bc49ded7f5c894cdfff85fef27b342b43a2659cc1a338173"
-dependencies = [
- "bitvec",
- "getrandom",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "cast"
@@ -355,17 +294,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "jobserver",
  "libc",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -416,17 +345,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,18 +368,6 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
-
-[[package]]
-name = "comfy-table"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
-dependencies = [
- "crossterm",
- "strum",
- "strum_macros",
- "unicode-width",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -593,38 +499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.4.1",
- "crossterm_winapi",
- "libc",
- "parking_lot 0.12.1",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
-dependencies = [
- "nix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,38 +557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -836,25 +682,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -862,12 +697,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -896,12 +725,6 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -999,15 +822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,59 +840,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
-name = "libloading"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1091,29 +856,6 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
-
-[[package]]
-name = "lmdb-rkv"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "lmdb-rkv-sys",
-]
-
-[[package]]
-name = "lmdb-rkv-sys"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "lock_api"
@@ -1144,30 +886,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "memoffset"
@@ -1177,12 +899,6 @@ checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1211,36 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1291,37 +977,12 @@ checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1332,16 +993,10 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"
@@ -1365,12 +1020,6 @@ dependencies = [
  "fastrand 2.0.1",
  "futures-io",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "plotters"
@@ -1437,16 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,12 +1102,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1558,24 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redb"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72623e6275cd430215b741f41ebda34db93a13ebde253f908b70871c46afc5ba"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,26 +1238,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1672,12 +1271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,26 +1284,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "sanakirja"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766699f1bb95f2e358c1ec0945da82b40097ec29a3a61636833f5ff27071c392"
-dependencies = [
- "fs2",
- "log",
- "memmap",
- "parking_lot 0.11.2",
- "sanakirja-core",
- "thiserror",
-]
-
-[[package]]
-name = "sanakirja-core"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18ebf28e53f067c2867f2cbae572f5e5320c1074ad2f9e6ed309df22277de6"
 
 [[package]]
 name = "scopeguard"
@@ -1750,12 +1323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,22 +1338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -1816,68 +1367,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "surrealkv"
 version = "0.1.0"
 dependencies = [
  "async-channel 2.1.1",
  "async-std",
- "async-task",
  "bytes",
- "caches",
  "chrono",
- "comfy-table",
  "crc32fast",
  "criterion",
  "crossbeam",
  "crossbeam-channel",
- "ctrlc",
  "fastrand 2.0.1",
- "flume",
  "futures",
- "futures-lite 1.13.0",
  "hashbrown",
  "jemallocator",
- "libc",
- "lmdb-rkv",
  "lru",
  "nanoid",
- "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand 0.8.5",
- "redb",
- "rocksdb",
- "sanakirja",
- "sled",
  "tempdir",
- "tempfile",
  "tokio",
 ]
 
@@ -1893,12 +1402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,39 +1409,6 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
-dependencies = [
- "cfg-if",
- "fastrand 2.0.1",
- "redox_syscall 0.4.1",
- "rustix 0.38.28",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1962,7 +1432,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
@@ -2004,22 +1474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
 name = "value-bag"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126e423afe2dd9ac52142e7e9d5ce4135d7e13776c529d27fd6bc49f19e3280b"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2298,15 +1756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.7.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,14 +1773,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ comfy-table = "7.0.1"
 
 tempdir = "0.3"
 rand = "0.8.5"
-criterion = "0.5.1"
+criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 jemallocator = "0.5.4"
 nanoid = "0.4.0"
 caches = "0.2" 
@@ -54,7 +54,3 @@ fastrand = "2.0.1"
 [[bench]]
 name = "store_bench"
 harness = false
-
-[[bin]]
-name = "rocks_bench"
-path = "example/rocks_bench.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ hashbrown = "0.14.2"
 lru = "0.12.0"
 async-channel = "2.1.1"
 futures = "0.3.30"
-async-std = "1.12.0"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,35 +20,12 @@ bytes = "1.5.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-
-# below is for the async runtime
-async-task = "4.4.0"
-futures-lite = "1.12.0"
-once_cell = "1.17.1"
-flume = "0.11.0"
-
-tempfile = "3.5.0"
-# for backwards compatibility testing - pin at 1.0.0
-redb = "1.5.0"
-
-# Just benchmarking dependencies
-ctrlc = "3.2.3"
-lmdb-rkv = "0.14.0"
-sanakirja = "1.3.3"
-sled = "0.34.7"
-rocksdb = "0.21.0"
-libc = "0.2.99"
-comfy-table = "7.0.1"
-
-
 tempdir = "0.3"
 rand = "0.8.5"
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 jemallocator = "0.5.4"
 nanoid = "0.4.0"
-caches = "0.2" 
 fastrand = "2.0.1"
-
 
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,34 @@ crossbeam-channel = "0.5.8"
 parking_lot = "0.12.1"
 hashbrown = "0.14.2"
 lru = "0.12.0"
+async-channel = "2.1.1"
+futures = "0.3.30"
+async-std = "1.12.0"
+bytes = "1.5.0"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }
 
 # below is for the async runtime
 async-task = "4.4.0"
 futures-lite = "1.12.0"
 once_cell = "1.17.1"
 flume = "0.11.0"
-bytes = "1.5.0"
 
-[dev-dependencies]
+tempfile = "3.5.0"
+# for backwards compatibility testing - pin at 1.0.0
+redb = "1.5.0"
+
+# Just benchmarking dependencies
+ctrlc = "3.2.3"
+lmdb-rkv = "0.14.0"
+sanakirja = "1.3.3"
+sled = "0.34.7"
+rocksdb = "0.21.0"
+libc = "0.2.99"
+comfy-table = "7.0.1"
+
+
 tempdir = "0.3"
 rand = "0.8.5"
 criterion = "0.5.1"
@@ -30,6 +49,12 @@ nanoid = "0.4.0"
 caches = "0.2" 
 fastrand = "2.0.1"
 
+
+
 [[bench]]
-name = "s3fifo_bench"
+name = "store_bench"
 harness = false
+
+[[bin]]
+name = "rocks_bench"
+path = "example/rocks_bench.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ async-channel = "2.1.1"
 futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt"] }
+sha2 = "0.10.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt"] }
 sha2 = "0.10.8"
+quick_cache = "0.4.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ async-channel = "2.1.1"
 futures = "0.3.30"
 async-std = "1.12.0"
 bytes = "1.5.0"
+tokio = { version = "1.36", features = ["rt"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "surrealkv"
+publish = true
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+readme = "README.md"
+description = "A low-level, versioned, embedded, ACID-compliant, key-value database for Rust"
+repository = "https://github.com/surrealdb/surrealkv"
+homepage = "https://github.com/surrealdb/surrealkv"
+documentation = "https://docs.rs/surrealkv/"
+keywords = ["lmdb", "rocksdb", "sled", "redb", "tikv"]
+categories = ["database-implementations", "concurrency", "data-structures"]
+rust-version = "1.75"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of SurrealDB code, software, and cloud platform very 
+seriously. If you believe you have found a security vulnerability in 
+SurrealDB, we encourage you to let us know right away. We will investigate 
+all legitimate reports and do our best to quickly fix the problem.
+
+Please report any issues or vulnerabilities to security@surrealdb.com, 
+instead of posting a public issue in GitHub. Please include the version 
+identifier, and details on how the vulnerability can be exploited.

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 
-use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 use jemallocator::Jemalloc;
 
@@ -156,4 +155,5 @@ fn concurrent_insert(c: &mut Criterion) {
 
 criterion_group!(benches_sequential, bulk_insert, sequential_insert_read);
 criterion_group!(benches_concurrent, concurrent_insert);
-criterion_main!(benches_sequential, benches_concurrent);
+// criterion_main!(benches_sequential, benches_concurrent);
+criterion_main!(benches_concurrent);

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use criterion::{criterion_group, criterion_main, Criterion};
 use jemallocator::Jemalloc;
 
-use surrealkv::storage::kv::option::Options;
-use surrealkv::storage::kv::store::Store;
+use surrealkv::Options;
+use surrealkv::Store;
 use tempdir::TempDir;
 
 #[cfg_attr(any(target_os = "linux", target_os = "macos"), global_allocator)]

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -17,7 +17,7 @@ fn create_temp_directory() -> TempDir {
     TempDir::new("test").unwrap()
 }
 
-async fn bulk_insert(c: &mut Criterion) {
+fn bulk_insert(c: &mut Criterion) {
     let count = AtomicU32::new(0_u32);
     let bytes = |len| -> Vec<u8> {
         count

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -35,9 +35,11 @@ fn bulk_insert(c: &mut Criterion) {
             .build()
             .unwrap();
 
-        let mut opts = Options::new();
-        opts.dir = create_temp_directory().path().to_path_buf();
-        let db = Store::new(opts).expect("should create store");
+        let db = rt.block_on(async {
+            let mut opts = Options::new();
+            opts.dir = create_temp_directory().path().to_path_buf();
+            Store::new(opts).expect("should create store")
+        });
 
         c.bench_function(
             &format!("bulk load key/value lengths {}/{}", key_len, val_len),

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,7 @@
+pre-release-commit-message = "Release version"
+sign-commit = false
+tag-message = ""
+tag-prefix = ""
+publish = false
+push = false
+tag = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,6 @@
 pub mod storage;
+
+pub use storage::kv::error::{Error, Result};
+pub use storage::kv::option::Options;
+pub use storage::kv::store::Store;
+pub use storage::kv::transaction::Transaction;

--- a/src/storage/cache/s3fifo.rs
+++ b/src/storage/cache/s3fifo.rs
@@ -122,7 +122,7 @@ where
 
     fn evict(&mut self) {
         if self.small.len() + self.main.len() >= self.max_cache_size {
-            if self.main.len() >= self.max_main_size || self.small.len() == 0 {
+            if self.main.len() >= self.max_main_size || self.small.is_empty() {
                 self.evict_m();
             } else {
                 self.evict_s();

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -278,6 +278,12 @@ pub struct BitSet<const SIZE: usize> {
     bits: [bool; SIZE],
 }
 
+impl<const SIZE: usize> Default for BitSet<SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const SIZE: usize> BitSet<SIZE> {
     pub fn new() -> Self {
         Self {

--- a/src/storage/index/node.rs
+++ b/src/storage/index/node.rs
@@ -273,7 +273,7 @@ impl<P: KeyTrait + Clone, N: Version, const WIDTH: usize> NodeTrait<N> for FlatN
         let mut new_node = Self::new(self.prefix.clone());
         for i in 0..self.num_children as usize {
             new_node.keys[i] = self.keys[i];
-            new_node.children[i] =self.children[i].clone();
+            new_node.children[i] = self.children[i].clone();
         }
         new_node.num_children = self.num_children;
         new_node.version = self.version;

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -479,8 +479,8 @@ mod tests {
         TempDir::new("test").unwrap()
     }
 
-    #[test]
-    fn encode_decode() {
+    #[tokio::test]
+    async fn encode_decode() {
         // Create a sample valueRef instance
         // Create a temporary directory for testing
         let temp_dir = create_temp_directory();

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -466,185 +466,185 @@ impl ValueRef {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     use crate::storage::kv::option::Options;
-//     use crate::storage::kv::store::Store;
+    use crate::storage::kv::option::Options;
+    use crate::storage::kv::store::Store;
 
-//     use tempdir::TempDir;
+    use tempdir::TempDir;
 
-//     fn create_temp_directory() -> TempDir {
-//         TempDir::new("test").unwrap()
-//     }
+    fn create_temp_directory() -> TempDir {
+        TempDir::new("test").unwrap()
+    }
 
-//     #[test]
-//     fn encode_decode() {
-//         // Create a sample valueRef instance
-//         // Create a temporary directory for testing
-//         let temp_dir = create_temp_directory();
+    #[test]
+    fn encode_decode() {
+        // Create a sample valueRef instance
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
 
-//         // Create store options with the test directory
-//         let mut opts = Options::new();
-//         opts.dir = temp_dir.path().to_path_buf();
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
 
-//         // Create a new Core instance with VariableKey as the key type
-//         let store = Store::new(opts).expect("should create store");
+        // Create a new Core instance with VariableKey as the key type
+        let store = Store::new(opts).expect("should create store");
 
-//         let mut txmd = Metadata::new();
-//         txmd.as_deleted(true).expect("failed to set deleted");
-//         let mut kvmd = Metadata::new();
-//         kvmd.as_deleted(true).expect("failed to set deleted");
+        let mut txmd = Metadata::new();
+        txmd.as_deleted(true).expect("failed to set deleted");
+        let mut kvmd = Metadata::new();
+        kvmd.as_deleted(true).expect("failed to set deleted");
 
-//         let mut value_ref = ValueRef::new(store.core.clone());
-//         value_ref.value_length = 100;
-//         value_ref.value_offset = Some(200);
-//         value_ref.key_value_metadata = Some(kvmd);
+        let mut value_ref = ValueRef::new(store.core.clone());
+        value_ref.value_length = 100;
+        value_ref.value_offset = Some(200);
+        value_ref.key_value_metadata = Some(kvmd);
 
-//         // // Encode the valueRef
-//         // let encoded_bytes = value_ref.encode();
+        // // Encode the valueRef
+        // let encoded_bytes = value_ref.encode();
 
-//         // // Decode the encoded bytes into a new valueRef
-//         // let mut decoded_value_ref = ValueRef::new(store);
-//         // decoded_value_ref.decode(0, &encoded_bytes).unwrap();
+        // // Decode the encoded bytes into a new valueRef
+        // let mut decoded_value_ref = ValueRef::new(store);
+        // decoded_value_ref.decode(0, &encoded_bytes).unwrap();
 
-//         // // Check if the decoded valueRef matches the original
-//         // assert_eq!(decoded_value_ref.version, value_ref.version);
-//         // assert_eq!(decoded_value_ref.value_length, value_ref.value_length);
-//         // assert_eq!(decoded_value_ref.value_offset, value_ref.value_offset);
-//         // assert_eq!(
-//         //     decoded_value_ref.key_value_metadata.unwrap().deleted(),
-//         //     value_ref.key_value_metadata.unwrap().deleted()
-//         // );
-//     }
+        // // Check if the decoded valueRef matches the original
+        // assert_eq!(decoded_value_ref.version, value_ref.version);
+        // assert_eq!(decoded_value_ref.value_length, value_ref.value_length);
+        // assert_eq!(decoded_value_ref.value_offset, value_ref.value_offset);
+        // assert_eq!(
+        //     decoded_value_ref.key_value_metadata.unwrap().deleted(),
+        //     value_ref.key_value_metadata.unwrap().deleted()
+        // );
+    }
 
-//     #[test]
-//     fn txn_with_value_read_from_clog() {
-//         // Create a temporary directory for testing
-//         let temp_dir = create_temp_directory();
+    #[tokio::test]
+    async fn txn_with_value_read_from_clog() {
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
 
-//         // Create store options with the test directory
-//         let mut opts = Options::new();
-//         opts.dir = temp_dir.path().to_path_buf();
-//         opts.max_value_threshold = 2;
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
+        opts.max_value_threshold = 2;
 
-//         // Create a new Core instance with VariableKey as the key type
-//         let store = Store::new(opts).expect("should create store");
+        // Create a new Core instance with VariableKey as the key type
+        let store = Store::new(opts).expect("should create store");
 
-//         // Define test keys and value
-//         let key1 = Bytes::from("foo1");
-//         let key2 = Bytes::from("foo2");
-//         let key3 = Bytes::from("foo3");
-//         let value = Bytes::from("bar");
+        // Define test keys and value
+        let key1 = Bytes::from("foo1");
+        let key2 = Bytes::from("foo2");
+        let key3 = Bytes::from("foo3");
+        let value = Bytes::from("bar");
 
-//         {
-//             // Start a new write transaction (txn)
-//             let mut txn = store.begin().unwrap();
+        {
+            // Start a new write transaction (txn)
+            let mut txn = store.begin().await.unwrap();
 
-//             // Set key1 and key2 with the same value
-//             txn.set(&key1, &value).unwrap();
-//             txn.set(&key2, &value).unwrap();
+            // Set key1 and key2 with the same value
+            txn.set(&key1, &value).unwrap();
+            txn.set(&key2, &value).unwrap();
 
-//             // Commit the transaction
-//             txn.commit().await();
-//         }
+            // Commit the transaction
+            txn.commit().await.unwrap();
+        }
 
-//         {
-//             // Start a new read-only transaction
-//             let txn = store.begin().unwrap();
+        {
+            // Start a new read-only transaction
+            let txn = store.begin().await.unwrap();
 
-//             // Retrieve the value associated with key1
-//             let val = txn.get(&key1).unwrap();
+            // Retrieve the value associated with key1
+            let val = txn.get(&key1).unwrap();
 
-//             // Assert that the value retrieved in txn matches the expected value
-//             assert_eq!(&val[..], value.as_ref());
-//         }
+            // Assert that the value retrieved in txn matches the expected value
+            assert_eq!(&val[..], value.as_ref());
+        }
 
-//         {
-//             // Start a new read-only transaction
-//             let txn = store.begin().unwrap();
+        {
+            // Start a new read-only transaction
+            let txn = store.begin().await.unwrap();
 
-//             // Retrieve the value associated with key2
-//             let val = txn.get(&key2).unwrap();
+            // Retrieve the value associated with key2
+            let val = txn.get(&key2).unwrap();
 
-//             // Assert that the value retrieved in txn matches the expected value
-//             assert_eq!(val, value);
-//         }
+            // Assert that the value retrieved in txn matches the expected value
+            assert_eq!(val, value);
+        }
 
-//         {
-//             // Start a new write transaction
-//             let mut txn = store.begin().unwrap();
+        {
+            // Start a new write transaction
+            let mut txn = store.begin().await.unwrap();
 
-//             // Set key3 with the same value
-//             txn.set(&key3, &value).unwrap();
+            // Set key3 with the same value
+            txn.set(&key3, &value).unwrap();
 
-//             // Commit the transaction
-//             txn.commit().unwrap();
-//         }
+            // Commit the transaction
+            txn.commit().await.unwrap();
+        }
 
-//         {
-//             // Start a new read-only transaction
-//             let txn = store.begin().unwrap();
+        {
+            // Start a new read-only transaction
+            let txn = store.begin().await.unwrap();
 
-//             // Retrieve the value associated with key3
-//             let val = txn.get(&key3).unwrap();
+            // Retrieve the value associated with key3
+            let val = txn.get(&key3).unwrap();
 
-//             // Assert that the value retrieved in txn matches the expected value
-//             assert_eq!(val, value);
-//         }
-//     }
+            // Assert that the value retrieved in txn matches the expected value
+            assert_eq!(val, value);
+        }
+    }
 
-//     #[test]
-//     fn txn_with_value_read_from_memory() {
-//         // Create a temporary directory for testing
-//         let temp_dir = create_temp_directory();
+    #[tokio::test]
+    async fn txn_with_value_read_from_memory() {
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
 
-//         // Create store options with the test directory
-//         let mut opts = Options::new();
-//         opts.dir = temp_dir.path().to_path_buf();
-//         opts.max_value_threshold = 40;
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
+        opts.max_value_threshold = 40;
 
-//         // Create a new Core instance with VariableKey as the key type
-//         let store = Store::new(opts).expect("should create store");
+        // Create a new Core instance with VariableKey as the key type
+        let store = Store::new(opts).expect("should create store");
 
-//         // Define test keys and value
-//         let key1 = Bytes::from("foo1");
-//         let key2 = Bytes::from("foo2");
-//         let value = Bytes::from("bar");
+        // Define test keys and value
+        let key1 = Bytes::from("foo1");
+        let key2 = Bytes::from("foo2");
+        let value = Bytes::from("bar");
 
-//         {
-//             // Start a new write transaction (txn)
-//             let mut txn = store.begin().unwrap();
+        {
+            // Start a new write transaction (txn)
+            let mut txn = store.begin().await.unwrap();
 
-//             // Set key1 and key2 with the same value
-//             txn.set(&key1, &value).unwrap();
-//             txn.set(&key2, &value).unwrap();
+            // Set key1 and key2 with the same value
+            txn.set(&key1, &value).unwrap();
+            txn.set(&key2, &value).unwrap();
 
-//             // Commit the transaction
-//             txn.commit().unwrap();
-//         }
+            // Commit the transaction
+            txn.commit().await.unwrap();
+        }
 
-//         {
-//             // Start a new read-only transaction
-//             let txn = store.begin().unwrap();
+        {
+            // Start a new read-only transaction
+            let txn = store.begin().await.unwrap();
 
-//             // Retrieve the value associated with key1
-//             let val = txn.get(&key1).unwrap();
+            // Retrieve the value associated with key1
+            let val = txn.get(&key1).unwrap();
 
-//             // Assert that the value retrieved in txn matches the expected value
-//             assert_eq!(&val[..], value.as_ref());
-//         }
+            // Assert that the value retrieved in txn matches the expected value
+            assert_eq!(&val[..], value.as_ref());
+        }
 
-//         {
-//             // Start a new read-only transaction
-//             let txn = store.begin().unwrap();
+        {
+            // Start a new read-only transaction
+            let txn = store.begin().await.unwrap();
 
-//             // Retrieve the value associated with key2
-//             let val = txn.get(&key2).unwrap();
+            // Retrieve the value associated with key2
+            let val = txn.get(&key2).unwrap();
 
-//             // Assert that the value retrieved in txn matches the expected value
-//             assert_eq!(val, value);
-//         }
-//     }
-// }
+            // Assert that the value retrieved in txn matches the expected value
+            assert_eq!(val, value);
+        }
+    }
+}

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -447,7 +447,7 @@ impl ValueRef {
     /// Otherwise, it reads the value from the commit log, caches it, and returns it.
     fn resolve_from_offset(&self, value_offset: u64) -> Result<Vec<u8>> {
         // Check if the offset exists in value_cache and return if found
-        if let Some(value) = self.store.value_cache.write().get(&value_offset) {
+        if let Some(value) = self.store.value_cache.get(&value_offset) {
             return Ok(value.to_vec());
         }
 
@@ -459,8 +459,7 @@ impl ValueRef {
         // Store the offset and value in value_cache
         self.store
             .value_cache
-            .write()
-            .push(value_offset, Bytes::from(buf.clone()));
+            .insert(value_offset, Bytes::from(buf.clone()));
 
         Ok(buf)
     }

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -540,7 +540,7 @@ mod tests {
 
         {
             // Start a new write transaction (txn)
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Set key1 and key2 with the same value
             txn.set(&key1, &value).unwrap();
@@ -552,7 +552,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
             let val = txn.get(&key1).unwrap();
@@ -563,7 +563,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
             let val = txn.get(&key2).unwrap();
@@ -574,7 +574,7 @@ mod tests {
 
         {
             // Start a new write transaction
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Set key3 with the same value
             txn.set(&key3, &value).unwrap();
@@ -585,7 +585,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key3
             let val = txn.get(&key3).unwrap();
@@ -615,7 +615,7 @@ mod tests {
 
         {
             // Start a new write transaction (txn)
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Set key1 and key2 with the same value
             txn.set(&key1, &value).unwrap();
@@ -627,7 +627,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
             let val = txn.get(&key1).unwrap();
@@ -638,7 +638,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
             let val = txn.get(&key2).unwrap();

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -555,7 +555,7 @@ mod tests {
             let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
-            let val = txn.get(&key1).unwrap();
+            let val = txn.get(&key1).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
             assert_eq!(&val[..], value.as_ref());
@@ -566,7 +566,7 @@ mod tests {
             let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
-            let val = txn.get(&key2).unwrap();
+            let val = txn.get(&key2).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
             assert_eq!(val, value);
@@ -588,7 +588,7 @@ mod tests {
             let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key3
-            let val = txn.get(&key3).unwrap();
+            let val = txn.get(&key3).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
             assert_eq!(val, value);
@@ -630,7 +630,7 @@ mod tests {
             let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
-            let val = txn.get(&key1).unwrap();
+            let val = txn.get(&key1).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
             assert_eq!(&val[..], value.as_ref());
@@ -641,7 +641,7 @@ mod tests {
             let txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
-            let val = txn.get(&key2).unwrap();
+            let val = txn.get(&key2).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
             assert_eq!(val, value);

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 pub(crate) mod indexer;
 pub(crate) mod meta;
 pub mod option;
-pub mod oracle;
+pub(crate) mod oracle;
 pub(crate) mod reader;
 pub mod snapshot;
 pub mod store;

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -159,7 +159,7 @@ impl SnapshotIsolation {
     /// are still valid in the latest snapshot, and if the timestamp of the read keys matches the timestamp
     /// of the latest snapshot. If the timestamp does not match, then there is a conflict.
     pub(crate) fn new_commit_ts(&self, txn: &mut Transaction) -> Result<u64> {
-        let current_snapshot = Snapshot::take(txn.store.clone(), self.read_ts())?;
+        let current_snapshot = Snapshot::take(txn.core.clone(), self.read_ts())?;
         let read_set = txn.read_set.lock();
 
         for (key, ts) in read_set.iter() {

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -7,6 +7,7 @@ use std::{
     },
 };
 
+use async_std::sync::Mutex as AsyncMutex;
 use bytes::Bytes;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use hashbrown::{HashMap, HashSet};
@@ -27,7 +28,7 @@ use crate::storage::{
 /// It supports two isolation levels: SnapshotIsolation and SerializableSnapshotIsolation.
 pub(crate) struct Oracle {
     /// Write lock to ensure that only one transaction can commit at a time.
-    pub(crate) write_lock: Mutex<()>,
+    pub(crate) write_lock: AsyncMutex<()>,
     /// Isolation level of the transactions.
     isolation: IsolationLevel,
 }
@@ -46,7 +47,7 @@ impl Oracle {
         };
 
         Self {
-            write_lock: Mutex::new(()),
+            write_lock: AsyncMutex::new(()),
             isolation,
         }
     }

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -7,11 +7,11 @@ use std::{
     },
 };
 
-use async_std::sync::Mutex as AsyncMutex;
 use bytes::Bytes;
 use crossbeam_channel::{bounded, Receiver, Sender};
 use hashbrown::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::storage::{
     index::art::TrieError,

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -334,7 +334,9 @@ impl SerializableSnapshotIsolation {
         assert!(ts >= commit_tracker.last_cleanup_ts);
 
         // Add the transaction to the list of committed transactions with conflict keys.
-        let conflict_keys = txn.write_set.keys().cloned().collect();
+        let conflict_keys: HashSet<Bytes> =
+            txn.write_set.iter().map(|(key, _)| key.clone()).collect();
+
         commit_tracker
             .committed_transactions
             .push(CommitMarker { ts, conflict_keys });

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -127,6 +127,7 @@ impl TaskRunner {
                         let task = req.unwrap();
                         self.handle_task(task).await
                     },
+                    // TODO: need to consume all transactions from channel
                     _ = self.stop_rx.recv().fuse() => {
                         drop(self);
                         return;

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -4,8 +4,9 @@ use std::{num::NonZeroUsize, sync::atomic::AtomicBool};
 
 use async_channel::{bounded, Receiver, Sender};
 use async_std::task::{spawn, JoinHandle};
-use bytes::{Bytes, BytesMut};
 use futures::{select, FutureExt};
+
+use bytes::{Bytes, BytesMut};
 use hashbrown::HashMap;
 use lru::LruCache;
 use parking_lot::RwLock;

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -550,7 +550,7 @@ mod tests {
         for (_, key) in keys.iter().enumerate() {
             // Start a new read transaction
             let txn = store.begin().unwrap();
-            let val = txn.get(key).unwrap();
+            let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn3 matches default_value
             assert_eq!(val, default_value.as_ref());
         }
@@ -569,7 +569,7 @@ mod tests {
         for (_, key) in keys.iter().enumerate() {
             // Start a new read transaction
             let txn = store.begin().unwrap();
-            let val = txn.get(key).unwrap();
+            let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn matches default_value
             assert_eq!(val, default_value.as_ref());
         }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -3,7 +3,7 @@ use std::vec;
 use std::{num::NonZeroUsize, sync::atomic::AtomicBool};
 
 use async_channel::{bounded, Receiver, Sender};
-use async_std::task::{spawn, JoinHandle};
+use tokio::task::{spawn, JoinHandle};
 use futures::{select, FutureExt};
 
 use bytes::{Bytes, BytesMut};

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -110,7 +110,12 @@ impl Store {
 
         // Wait for task to finish
         if let Some(handle) = self.task_runner_handle.write().take() {
-            handle.await;
+            handle.await.map_err(|e| {
+                Error::ReceiveError(format!(
+                    "Error occurred while closing the kv store. JoinError: {}",
+                    e.to_string()
+                ))
+            })?;
         }
 
         self.core.close()?;

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -3,8 +3,8 @@ use std::vec;
 use std::{num::NonZeroUsize, sync::atomic::AtomicBool};
 
 use async_channel::{bounded, Receiver, Sender};
-use tokio::task::{spawn, JoinHandle};
 use futures::{select, FutureExt};
+use tokio::task::{spawn, JoinHandle};
 
 use bytes::{Bytes, BytesMut};
 use hashbrown::HashMap;

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -423,7 +423,7 @@ mod tests {
 
         {
             // Start a new read-write transaction (txn1)
-            let mut txn1 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
             txn1.set(&key1, &value1).unwrap();
             txn1.set(&key2, &value1).unwrap();
             txn1.commit().await.unwrap();
@@ -431,14 +431,14 @@ mod tests {
 
         {
             // Start a read-only transaction (txn3)
-            let txn3 = store.begin().await.unwrap();
+            let txn3 = store.begin().unwrap();
             let val = txn3.get(&key1).unwrap();
             assert_eq!(val, value1.as_ref());
         }
 
         {
             // Start another read-write transaction (txn2)
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().unwrap();
             txn2.set(&key1, &value2).unwrap();
             txn2.set(&key2, &value2).unwrap();
             txn2.commit().await.unwrap();
@@ -453,7 +453,7 @@ mod tests {
         let store = Store::new(opts).expect("should create store");
 
         // Start a read-only transaction (txn4)
-        let txn4 = store.begin().await.unwrap();
+        let txn4 = store.begin().unwrap();
         let val = txn4.get(&key1).unwrap();
 
         // Assert that the value retrieved in txn4 matches value2
@@ -470,7 +470,7 @@ mod tests {
 
         {
             // Start a new read-write transaction (txn1)
-            let mut txn1 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
             txn1.set(&key1, &value1).unwrap();
             txn1.set(&key1, &value1).unwrap();
             txn1.commit().await.unwrap();
@@ -478,20 +478,20 @@ mod tests {
 
         {
             // Start a read-only transaction (txn)
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
             txn.delete(&key1).unwrap();
             txn.commit().await.unwrap();
         }
 
         {
             // Start another read-write transaction (txn)
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
             assert!(txn.get(&key1).is_err());
         }
 
         {
             let range = "k1".as_bytes()..="k3".as_bytes();
-            let txn = store.begin().await.unwrap();
+            let txn = store.begin().unwrap();
             let results = txn.scan(range).unwrap();
             assert_eq!(results.len(), 0);
         }
@@ -507,8 +507,8 @@ mod tests {
 
         // no read conflict
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             txn1.set(&key1, &value1).unwrap();
             txn1.commit().await.unwrap();
@@ -520,8 +520,8 @@ mod tests {
 
         // read conflict when the read key was updated by another transaction
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             txn1.set(&key1, &value1).unwrap();
             txn1.commit().await.unwrap();
@@ -542,8 +542,8 @@ mod tests {
 
         // blind writes should succeed if key wasn't read first
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             txn1.set(&key1, &value1).unwrap();
             txn2.set(&key1, &value2).unwrap();
@@ -551,7 +551,7 @@ mod tests {
             txn1.commit().await.unwrap();
             txn2.commit().await.unwrap();
 
-            let txn3 = store.begin().await.unwrap();
+            let txn3 = store.begin().unwrap();
             let val = txn3.get(&key1).unwrap();
             assert_eq!(val, value2.as_ref());
         }
@@ -560,8 +560,8 @@ mod tests {
         {
             let key = Bytes::from("key3");
 
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             txn1.set(&key, &value1).unwrap();
             txn1.commit().await.unwrap();
@@ -584,12 +584,12 @@ mod tests {
         {
             let key = Bytes::from("key4");
 
-            let mut txn1 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
             txn1.set(&key, &value1).unwrap();
             txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().await.unwrap();
-            let mut txn3 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().unwrap();
+            let mut txn3 = store.begin().unwrap();
 
             txn2.delete(&key).unwrap();
             assert!(txn2.commit().await.is_ok());
@@ -626,14 +626,14 @@ mod tests {
         let keys_to_insert = vec![Bytes::from("key1")];
 
         for key in &keys_to_insert {
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
             txn.set(key, key).unwrap();
             txn.commit().await.unwrap();
         }
 
         let range = "key1".as_bytes()..="key3".as_bytes();
 
-        let txn = store.begin().await.unwrap();
+        let txn = store.begin().unwrap();
         let results = txn.scan(range).unwrap();
         assert_eq!(results.len(), keys_to_insert.len());
     }
@@ -650,14 +650,14 @@ mod tests {
         ];
 
         for key in &keys_to_insert {
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
             txn.set(key, key).unwrap();
             txn.commit().await.unwrap();
         }
 
         let range = "key1".as_bytes()..="key3".as_bytes();
 
-        let txn = store.begin().await.unwrap();
+        let txn = store.begin().unwrap();
         let results = txn.scan(range).unwrap();
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].0, keys_to_insert[0]);
@@ -681,13 +681,13 @@ mod tests {
 
         // read conflict when scan keys have been updated in another transaction
         {
-            let mut txn1 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
 
             txn1.set(&key1, &value1).unwrap();
             txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().await.unwrap();
-            let mut txn3 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().unwrap();
+            let mut txn3 = store.begin().unwrap();
 
             txn2.set(&key1, &value4).unwrap();
             txn2.set(&key2, &value2).unwrap();
@@ -714,13 +714,13 @@ mod tests {
 
         // read conflict when read keys are deleted by other transaction
         {
-            let mut txn1 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
 
             txn1.set(&key4, &value1).unwrap();
             txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().await.unwrap();
-            let mut txn3 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().unwrap();
+            let mut txn3 = store.begin().unwrap();
 
             txn2.delete(&key4).unwrap();
             txn2.commit().await.unwrap();
@@ -766,14 +766,14 @@ mod tests {
         let value2 = Bytes::from("v2");
 
         {
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
             txn.set(&key1, &value1).unwrap();
             txn.commit().await.unwrap();
         }
 
         {
             // Start a new read-write transaction (txn)
-            let mut txn = store.begin().await.unwrap();
+            let mut txn = store.begin().unwrap();
             txn.set(&key1, &value2).unwrap();
             assert_eq!(txn.get(&key1).unwrap(), value2.as_ref());
             assert!(txn.get(&key3).is_err());
@@ -792,7 +792,7 @@ mod tests {
         let value1 = Bytes::from("v1");
         let value2 = Bytes::from("v2");
         // Start a new read-write transaction (txn)
-        let mut txn = store.begin().await.unwrap();
+        let mut txn = store.begin().unwrap();
         txn.set(&key1, &value1).unwrap();
         txn.set(&key2, &value2).unwrap();
         txn.commit().await.unwrap();
@@ -814,8 +814,8 @@ mod tests {
         let value6 = Bytes::from("v6");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn1.get(&key2).is_ok());
@@ -843,7 +843,7 @@ mod tests {
         }
 
         {
-            let txn3 = store.begin().await.unwrap();
+            let txn3 = store.begin().unwrap();
             let val1 = txn3.get(&key1).unwrap();
             assert_eq!(val1, value3.as_ref());
             let val2 = txn3.get(&key2).unwrap();
@@ -867,8 +867,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
 
@@ -889,7 +889,7 @@ mod tests {
         }
 
         {
-            let txn3 = store.begin().await.unwrap();
+            let txn3 = store.begin().unwrap();
             let val1 = txn3.get(&key1).unwrap();
             assert_eq!(val1, value1.as_ref());
             let val2 = txn3.get(&key2).unwrap();
@@ -914,8 +914,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn1.get(&key2).is_ok());
@@ -956,8 +956,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn2.get(&key2).is_ok());
@@ -998,8 +998,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             // k3 should not be visible to txn1
             let range = "k1".as_bytes()..="k3".as_bytes();
@@ -1038,8 +1038,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             txn1.set(&key1, &value3).unwrap();
@@ -1085,8 +1085,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn2.get(&key1).is_ok());
@@ -1127,8 +1127,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
             assert_eq!(txn2.get(&key1).unwrap(), value1.as_ref());
@@ -1161,8 +1161,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
 
@@ -1210,8 +1210,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
             let range = "k1".as_bytes()..="k2".as_bytes();
@@ -1249,8 +1249,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().await.unwrap();
-            let mut txn2 = store.begin().await.unwrap();
+            let mut txn1 = store.begin().unwrap();
+            let mut txn2 = store.begin().unwrap();
 
             let range = "k1".as_bytes()..="k2".as_bytes();
             let res = txn1.scan(range.clone()).unwrap();
@@ -1294,10 +1294,10 @@ mod tests {
     async fn is_send_sync() {
         let (db, _) = create_store(false);
 
-        let txn = db.begin().await.unwrap();
+        let txn = db.begin().unwrap();
         require_send(txn);
 
-        let txn = db.begin().await.unwrap();
+        let txn = db.begin().unwrap();
         require_sync(txn);
     }
 
@@ -1328,7 +1328,7 @@ mod tests {
         let default_value = Bytes::from("default_value".to_string());
 
         // Writing the 6th key should fail
-        let mut txn = store.begin().await.unwrap();
+        let mut txn = store.begin().unwrap();
 
         for (i, key) in keys.iter().enumerate() {
             // Start a new write transaction
@@ -1396,7 +1396,7 @@ mod tests {
         let store = Store::new(opts.clone()).expect("should create store");
         let mut rng = make_rng();
 
-        let mut txn = store.begin().await.unwrap();
+        let mut txn = store.begin().unwrap();
         for _ in 0..ENTRIES {
             let (key, value) = gen_pair(&mut rng);
             txn.set(&key, &value).unwrap();
@@ -1406,7 +1406,7 @@ mod tests {
 
         // Read the keys from the store
         let mut rng = make_rng();
-        let txn = store.begin_with_mode(Mode::ReadOnly).await.unwrap();
+        let txn = store.begin_with_mode(Mode::ReadOnly).unwrap();
         for _i in 0..ENTRIES {
             let (key, _) = gen_pair(&mut rng);
             txn.get(&key).unwrap();

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -74,8 +74,8 @@ pub struct Transaction {
     /// `buf` is a reusable buffer for encoding transaction records. This is used to reduce memory allocations.
     buf: BytesMut,
 
-    /// `store` is the underlying store for the transaction. This is shared between transactions.
-    pub(crate) store: Arc<Core>,
+    /// `core` is the underlying core for the transaction. This is shared between transactions.
+    pub(crate) core: Arc<Core>,
 
     /// `write_set` is the pending writes for the transaction. These are the changes that the transaction wants to make to the data.
     pub(crate) write_set: HashMap<Bytes, Entry>,
@@ -92,16 +92,16 @@ pub struct Transaction {
 
 impl Transaction {
     /// Prepare a new transaction in the given mode.
-    pub fn new(store: Arc<Core>, mode: Mode) -> Result<Self> {
-        let snapshot = RwLock::new(Snapshot::take(store.clone(), now())?);
-        let read_ts = store.read_ts()?;
+    pub fn new(core: Arc<Core>, mode: Mode) -> Result<Self> {
+        let snapshot = RwLock::new(Snapshot::take(core.clone(), now())?);
+        let read_ts = core.read_ts()?;
 
         Ok(Self {
             read_ts,
             mode,
             snapshot,
             buf: BytesMut::new(),
-            store,
+            core,
             write_set: HashMap::new(),
             read_set: Mutex::new(Vec::new()),
             committed_values_offsets: HashMap::new(),
@@ -195,15 +195,15 @@ impl Transaction {
             return Err(Error::EmptyKey);
         }
         // If the key length exceeds the maximum allowed key size, return an error.
-        if e.key.len() as u64 > self.store.opts.max_key_size {
+        if e.key.len() as u64 > self.core.opts.max_key_size {
             return Err(Error::MaxKeyLengthExceeded);
         }
         // If the value length exceeds the maximum allowed value size, return an error.
-        if e.value.len() as u64 > self.store.opts.max_value_size {
+        if e.value.len() as u64 > self.core.opts.max_value_size {
             return Err(Error::MaxValueLengthExceeded);
         }
 
-        if self.write_set.len() as u32 >= self.store.opts.max_tx_entries {
+        if self.write_set.len() as u32 >= self.core.opts.max_tx_entries {
             return Err(Error::MaxTransactionEntriesLimitExceeded);
         }
 
@@ -266,7 +266,7 @@ impl Transaction {
         // Iterate over the keys in the range.
         'outer: for (key, value, version, ts) in ranger {
             // Create a new value reference and decode the value.
-            let mut val_ref = ValueRef::new(self.store.clone());
+            let mut val_ref = ValueRef::new(self.core.clone());
             let val_bytes_ref: &Bytes = value;
             val_ref.decode(*version, val_bytes_ref)?;
 
@@ -298,7 +298,7 @@ impl Transaction {
     }
 
     /// Commits the transaction, by writing all pending entries to the store.
-    pub fn commit(&mut self) -> Result<()> {
+    pub async fn commit(&mut self) -> Result<()> {
         // If the transaction is closed, return an error.
         if self.closed {
             return Err(Error::TransactionClosed);
@@ -316,30 +316,48 @@ impl Transaction {
 
         // TODO: Use a commit pipeline to avoid blocking calls.
         // Lock the oracle to serialize commits to the transaction log.
-        let oracle = self.store.oracle.clone();
-        let _lock = oracle.write_lock.lock();
+        let oracle = self.core.oracle.clone();
+        let write_ch_lock = oracle.write_lock.lock();
 
         // Prepare for the commit by getting a transaction ID and a commit timestamp.
         let (tx_id, commit_ts) = self.prepare_commit()?;
+        let entries = self.write_set.values().cloned().collect();
 
-        // Add transaction records to the transaction log.
-        self.add_to_transaction_log(tx_id, commit_ts)?;
+        let done = self
+            .core
+            .send_to_write_channel(entries, tx_id, commit_ts)
+            .await;
 
-        // Commit the changes to the store index.
-        self.commit_to_index(tx_id, commit_ts)?;
+        if let Err(err) = done {
+            oracle.committed_upto(commit_ts);
+            return Err(err);
+        }
+
+        drop(write_ch_lock);
+
+        // // Add transaction records to the transaction log.
+        // self.add_to_transaction_log(tx_id, commit_ts)?;
+
+        // // Commit the changes to the store index.
+        // self.commit_to_index(tx_id, commit_ts)?;
 
         // Update the oracle to indicate that the transaction has been committed up to the given transaction ID.
+        // oracle.committed_upto(tx_id);
+
+        let done = done.unwrap();
+        let ret = done.recv().await?;
         oracle.committed_upto(tx_id);
 
         // Mark the transaction as closed.
         self.closed = true;
 
-        Ok(())
+        // Ok(())
+        ret
     }
 
     /// Prepares for the commit by assigning commit timestamps and preparing records.
     fn prepare_commit(&mut self) -> Result<(u64, u64)> {
-        let oracle = self.store.oracle.clone();
+        let oracle = self.core.oracle.clone();
         let tx_id = oracle.new_commit_ts(self)?;
         let commit_ts = self.assign_commit_ts();
         Ok((tx_id, commit_ts))
@@ -356,7 +374,7 @@ impl Transaction {
 
     /// Adds transaction records to the transaction log.
     fn add_to_transaction_log(&mut self, tx_id: u64, commit_ts: u64) -> Result<u64> {
-        let current_offset = self.store.clog.read().offset()?;
+        let current_offset = self.core.clog.read().offset()?;
         let entries: Vec<Entry> = self.write_set.values().cloned().collect();
         let tx_record = TxRecord::new_with_entries(entries, tx_id, commit_ts);
         tx_record.encode(
@@ -365,14 +383,14 @@ impl Transaction {
             &mut self.committed_values_offsets,
         )?;
 
-        let mut clog = self.store.clog.write();
+        let mut clog = self.core.clog.write();
         let (tx_offset, _) = clog.append(self.buf.as_ref())?;
         Ok(tx_offset)
     }
 
     /// Commits transaction changes to the store index.
     fn commit_to_index(&mut self, tx_id: u64, commit_ts: u64) -> Result<()> {
-        let mut index = self.store.indexer.write();
+        let mut index = self.core.indexer.write();
         let mut kv_pairs = self.build_kv_pairs(tx_id, commit_ts);
 
         index.bulk_insert(&mut kv_pairs)?;
@@ -404,7 +422,7 @@ impl Transaction {
             &entry.value,
             entry.metadata.as_ref(),
             &self.committed_values_offsets,
-            self.store.opts.max_value_threshold,
+            self.core.opts.max_value_threshold,
         );
         index_value
     }
@@ -454,8 +472,8 @@ mod tests {
         )
     }
 
-    #[test]
-    fn basic_transaction() {
+    #[tokio::test]
+    async fn basic_transaction() {
         let (store, temp_dir) = create_store(false);
 
         // Define key-value pairs for the test
@@ -466,25 +484,25 @@ mod tests {
 
         {
             // Start a new read-write transaction (txn1)
-            let mut txn1 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
             txn1.set(&key1, &value1).unwrap();
             txn1.set(&key2, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
         }
 
         {
             // Start a read-only transaction (txn3)
-            let txn3 = store.begin().unwrap();
+            let txn3 = store.begin().await.unwrap();
             let val = txn3.get(&key1).unwrap();
             assert_eq!(val, value1.as_ref());
         }
 
         {
             // Start another read-write transaction (txn2)
-            let mut txn2 = store.begin().unwrap();
+            let mut txn2 = store.begin().await.unwrap();
             txn2.set(&key1, &value2).unwrap();
             txn2.set(&key2, &value2).unwrap();
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
         }
 
         // Drop the store to simulate closing it
@@ -496,15 +514,15 @@ mod tests {
         let store = Store::new(opts).expect("should create store");
 
         // Start a read-only transaction (txn4)
-        let txn4 = store.begin().unwrap();
+        let txn4 = store.begin().await.unwrap();
         let val = txn4.get(&key1).unwrap();
 
         // Assert that the value retrieved in txn4 matches value2
         assert_eq!(val, value2.as_ref());
     }
 
-    #[test]
-    fn transaction_delete_scan() {
+    #[tokio::test]
+    async fn transaction_delete_scan() {
         let (store, _) = create_store(false);
 
         // Define key-value pairs for the test
@@ -513,34 +531,34 @@ mod tests {
 
         {
             // Start a new read-write transaction (txn1)
-            let mut txn1 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
             txn1.set(&key1, &value1).unwrap();
             txn1.set(&key1, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
         }
 
         {
             // Start a read-only transaction (txn)
-            let mut txn = store.begin().unwrap();
+            let mut txn = store.begin().await.unwrap();
             txn.delete(&key1).unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         {
             // Start another read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let txn = store.begin().await.unwrap();
             assert!(txn.get(&key1).is_err());
         }
 
         {
             let range = "k1".as_bytes()..="k3".as_bytes();
-            let txn = store.begin().unwrap();
+            let txn = store.begin().await.unwrap();
             let results = txn.scan(range).unwrap();
             assert_eq!(results.len(), 0);
         }
     }
 
-    fn mvcc_tests(is_ssi: bool) {
+    async fn mvcc_tests(is_ssi: bool) {
         let (store, _) = create_store(is_ssi);
 
         let key1 = Bytes::from("key1");
@@ -550,28 +568,28 @@ mod tests {
 
         // no read conflict
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             txn1.set(&key1, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             assert!(txn2.get(&key2).is_err());
             txn2.set(&key2, &value2).unwrap();
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
         }
 
         // read conflict when the read key was updated by another transaction
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             txn1.set(&key1, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             assert!(txn2.get(&key1).is_ok());
             txn2.set(&key1, &value2).unwrap();
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -585,16 +603,16 @@ mod tests {
 
         // blind writes should succeed if key wasn't read first
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             txn1.set(&key1, &value1).unwrap();
             txn2.set(&key1, &value2).unwrap();
 
-            txn1.commit().unwrap();
-            txn2.commit().unwrap();
+            txn1.commit().await.unwrap();
+            txn2.commit().await.unwrap();
 
-            let txn3 = store.begin().unwrap();
+            let txn3 = store.begin().await.unwrap();
             let val = txn3.get(&key1).unwrap();
             assert_eq!(val, value2.as_ref());
         }
@@ -603,15 +621,15 @@ mod tests {
         {
             let key = Bytes::from("key3");
 
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             txn1.set(&key, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             assert!(txn2.get(&key).is_err());
             txn2.set(&key, &value1).unwrap();
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -627,19 +645,19 @@ mod tests {
         {
             let key = Bytes::from("key4");
 
-            let mut txn1 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
             txn1.set(&key, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().unwrap();
-            let mut txn3 = store.begin().unwrap();
+            let mut txn2 = store.begin().await.unwrap();
+            let mut txn3 = store.begin().await.unwrap();
 
             txn2.delete(&key).unwrap();
-            assert!(txn2.commit().is_ok());
+            assert!(txn2.commit().await.is_ok());
 
             assert!(txn3.get(&key).is_ok());
             txn3.set(&key, &value2).unwrap();
-            assert!(match txn3.commit() {
+            assert!(match txn3.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -652,37 +670,37 @@ mod tests {
         }
     }
 
-    #[test]
-    fn mvcc_serialized_snapshot_isolation() {
-        mvcc_tests(true);
+    #[tokio::test]
+    async fn mvcc_serialized_snapshot_isolation() {
+        mvcc_tests(true).await;
     }
 
-    #[test]
-    fn mvcc_snapshot_isolation() {
-        mvcc_tests(false);
+    #[tokio::test]
+    async fn mvcc_snapshot_isolation() {
+        mvcc_tests(false).await;
     }
 
-    #[test]
-    fn basic_scan_single_key() {
+    #[tokio::test]
+    async fn basic_scan_single_key() {
         let (store, _) = create_store(false);
         // Define key-value pairs for the test
         let keys_to_insert = vec![Bytes::from("key1")];
 
         for key in &keys_to_insert {
-            let mut txn = store.begin().unwrap();
+            let mut txn = store.begin().await.unwrap();
             txn.set(key, key).unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         let range = "key1".as_bytes()..="key3".as_bytes();
 
-        let txn = store.begin().unwrap();
+        let txn = store.begin().await.unwrap();
         let results = txn.scan(range).unwrap();
         assert_eq!(results.len(), keys_to_insert.len());
     }
 
-    #[test]
-    fn basic_scan_multiple_keys() {
+    #[tokio::test]
+    async fn basic_scan_multiple_keys() {
         let (store, _) = create_store(false);
         // Define key-value pairs for the test
         let keys_to_insert = vec![
@@ -693,14 +711,14 @@ mod tests {
         ];
 
         for key in &keys_to_insert {
-            let mut txn = store.begin().unwrap();
+            let mut txn = store.begin().await.unwrap();
             txn.set(key, key).unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         let range = "key1".as_bytes()..="key3".as_bytes();
 
-        let txn = store.begin().unwrap();
+        let txn = store.begin().await.unwrap();
         let results = txn.scan(range).unwrap();
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].0, keys_to_insert[0]);
@@ -708,7 +726,7 @@ mod tests {
         assert_eq!(results[2].0, keys_to_insert[2]);
     }
 
-    fn mvcc_with_scan_tests(is_ssi: bool) {
+    async fn mvcc_with_scan_tests(is_ssi: bool) {
         let (store, _) = create_store(is_ssi);
 
         let key1 = Bytes::from("key1");
@@ -724,18 +742,18 @@ mod tests {
 
         // read conflict when scan keys have been updated in another transaction
         {
-            let mut txn1 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
 
             txn1.set(&key1, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().unwrap();
-            let mut txn3 = store.begin().unwrap();
+            let mut txn2 = store.begin().await.unwrap();
+            let mut txn3 = store.begin().await.unwrap();
 
             txn2.set(&key1, &value4).unwrap();
             txn2.set(&key2, &value2).unwrap();
             txn2.set(&key3, &value3).unwrap();
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
 
             let range = "key1".as_bytes()..="key4".as_bytes();
             let results = txn3.scan(range).unwrap();
@@ -743,7 +761,7 @@ mod tests {
             txn3.set(&key2, &value5).unwrap();
             txn3.set(&key3, &value6).unwrap();
 
-            assert!(match txn3.commit() {
+            assert!(match txn3.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -757,22 +775,22 @@ mod tests {
 
         // read conflict when read keys are deleted by other transaction
         {
-            let mut txn1 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
 
             txn1.set(&key4, &value1).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
-            let mut txn2 = store.begin().unwrap();
-            let mut txn3 = store.begin().unwrap();
+            let mut txn2 = store.begin().await.unwrap();
+            let mut txn3 = store.begin().await.unwrap();
 
             txn2.delete(&key4).unwrap();
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
 
             let range = "key1".as_bytes()..="key5".as_bytes();
             txn3.scan(range).unwrap();
             txn3.set(&key4, &value2).unwrap();
 
-            assert!(match txn3.commit() {
+            assert!(match txn3.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -785,18 +803,18 @@ mod tests {
         }
     }
 
-    #[test]
-    fn mvcc_serialized_snapshot_isolation_scan() {
-        mvcc_with_scan_tests(true);
+    #[tokio::test]
+    async fn mvcc_serialized_snapshot_isolation_scan() {
+        mvcc_with_scan_tests(true).await;
     }
 
-    #[test]
-    fn mvcc_snapshot_isolation_scan() {
-        mvcc_with_scan_tests(false);
+    #[tokio::test]
+    async fn mvcc_snapshot_isolation_scan() {
+        mvcc_with_scan_tests(false).await;
     }
 
-    #[test]
-    fn ryow() {
+    #[tokio::test]
+    async fn ryow() {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
@@ -809,25 +827,25 @@ mod tests {
         let value2 = Bytes::from("v2");
 
         {
-            let mut txn = store.begin().unwrap();
+            let mut txn = store.begin().await.unwrap();
             txn.set(&key1, &value1).unwrap();
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
 
         {
             // Start a new read-write transaction (txn)
-            let mut txn = store.begin().unwrap();
+            let mut txn = store.begin().await.unwrap();
             txn.set(&key1, &value2).unwrap();
             assert_eq!(txn.get(&key1).unwrap(), value2.as_ref());
             assert!(txn.get(&key3).is_err());
             txn.set(&key2, &value1).unwrap();
             assert_eq!(txn.get(&key2).unwrap(), value1.as_ref());
-            txn.commit().unwrap();
+            txn.commit().await.unwrap();
         }
     }
 
     // Common setup logic for creating a store
-    fn create_hermitage_store(is_ssi: bool) -> Store {
+    async fn create_hermitage_store(is_ssi: bool) -> Store {
         let (store, _) = create_store(is_ssi);
 
         let key1 = Bytes::from("k1");
@@ -835,10 +853,10 @@ mod tests {
         let value1 = Bytes::from("v1");
         let value2 = Bytes::from("v2");
         // Start a new read-write transaction (txn)
-        let mut txn = store.begin().unwrap();
+        let mut txn = store.begin().await.unwrap();
         txn.set(&key1, &value1).unwrap();
         txn.set(&key2, &value2).unwrap();
-        txn.commit().unwrap();
+        txn.commit().await.unwrap();
 
         store
     }
@@ -847,8 +865,8 @@ mod tests {
     // Specifically, the tests are derived from FoundationDB tests: https://github.com/ept/hermitage/blob/master/foundationdb.md
 
     // G0: Write Cycles (dirty writes)
-    fn g0_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g0_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
         let value3 = Bytes::from("v3");
@@ -857,8 +875,8 @@ mod tests {
         let value6 = Bytes::from("v6");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn1.get(&key2).is_ok());
@@ -870,10 +888,10 @@ mod tests {
 
             txn1.set(&key2, &value5).unwrap();
 
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             txn2.set(&key2, &value6).unwrap();
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -886,7 +904,7 @@ mod tests {
         }
 
         {
-            let txn3 = store.begin().unwrap();
+            let txn3 = store.begin().await.unwrap();
             let val1 = txn3.get(&key1).unwrap();
             assert_eq!(val1, value3.as_ref());
             let val2 = txn3.get(&key2).unwrap();
@@ -894,15 +912,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn g0() {
-        g0_tests(false); // snapshot isolation
-        g0_tests(true); // serializable snapshot isolation
+    #[tokio::test]
+    async fn g0() {
+        g0_tests(false).await; // snapshot isolation
+        g0_tests(true).await; // serializable snapshot isolation
     }
 
     // G1a: Aborted Reads (dirty reads, cascaded aborts)
-    fn g1a_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g1a_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
         let value1 = Bytes::from("v1");
@@ -910,8 +928,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
 
@@ -928,11 +946,11 @@ mod tests {
             assert_eq!(res.len(), 2);
             assert_eq!(res[0].0, value1);
 
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
         }
 
         {
-            let txn3 = store.begin().unwrap();
+            let txn3 = store.begin().await.unwrap();
             let val1 = txn3.get(&key1).unwrap();
             assert_eq!(val1, value1.as_ref());
             let val2 = txn3.get(&key2).unwrap();
@@ -940,15 +958,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn g1a() {
-        g1a_tests(false); // snapshot isolation
-        g1a_tests(true); // serializable snapshot isolation
+    #[tokio::test]
+    async fn g1a() {
+        g1a_tests(false).await; // snapshot isolation
+        g1a_tests(true).await; // serializable snapshot isolation
     }
 
     // G1b: Intermediate Reads (dirty reads)
-    fn g1b_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g1b_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -957,8 +975,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn1.get(&key2).is_ok());
@@ -971,25 +989,25 @@ mod tests {
             assert_eq!(res[0].0, value1);
 
             txn1.set(&key1, &value4).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             let res = txn2.scan(range).unwrap();
             assert_eq!(res.len(), 2);
             assert_eq!(res[0].0, value1);
 
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
         }
     }
 
-    #[test]
-    fn g1b() {
-        g1b_tests(false); // snapshot isolation
-        g1b_tests(true); // serializable snapshot isolation
+    #[tokio::test]
+    async fn g1b() {
+        g1b_tests(false).await; // snapshot isolation
+        g1b_tests(true).await; // serializable snapshot isolation
     }
 
     // G1c: Circular Information Flow (dirty reads)
-    fn g1c_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g1c_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -999,8 +1017,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn2.get(&key2).is_ok());
@@ -1011,8 +1029,8 @@ mod tests {
             assert_eq!(txn1.get(&key2).unwrap(), value2.as_ref());
             assert_eq!(txn2.get(&key1).unwrap(), value1.as_ref());
 
-            txn1.commit().unwrap();
-            assert!(match txn2.commit() {
+            txn1.commit().await.unwrap();
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -1025,15 +1043,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn g1c() {
-        g1c_tests(false); // snapshot isolation
-        g1c_tests(true);
+    #[tokio::test]
+    async fn g1c() {
+        g1c_tests(false).await; // snapshot isolation
+        g1c_tests(true).await;
     }
 
     // PMP: Predicate-Many-Preceders
-    fn pmp_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn pmp_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key3 = Bytes::from("k3");
         let value1 = Bytes::from("v1");
@@ -1041,8 +1059,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             // k3 should not be visible to txn1
             let range = "k1".as_bytes()..="k3".as_bytes();
@@ -1053,7 +1071,7 @@ mod tests {
 
             // k3 is committed by txn2
             txn2.set(&key3, &value3).unwrap();
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
 
             // k3 should still not be visible to txn1
             let range = "k1".as_bytes()..="k3".as_bytes();
@@ -1064,15 +1082,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pmp() {
-        pmp_tests(false);
-        pmp_tests(true);
+    #[tokio::test]
+    async fn pmp() {
+        pmp_tests(false).await;
+        pmp_tests(true).await;
     }
 
     // PMP-Write: Circular Information Flow (dirty reads)
-    fn pmp_write_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn pmp_write_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -1081,8 +1099,8 @@ mod tests {
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             txn1.set(&key1, &value3).unwrap();
@@ -1094,14 +1112,14 @@ mod tests {
             assert_eq!(res[1].0, value2);
 
             txn2.delete(&key2).unwrap();
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
             let range = "k1".as_bytes()..="k3".as_bytes();
             let res = txn2.scan(range.clone()).unwrap();
             assert_eq!(res.len(), 1);
             assert_eq!(res[0].0, value1);
 
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -1114,22 +1132,22 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pmp_write() {
-        pmp_write_tests(false);
-        pmp_write_tests(true);
+    #[tokio::test]
+    async fn pmp_write() {
+        pmp_write_tests(false).await;
+        pmp_write_tests(true).await;
     }
 
     // P4: Lost Update
-    fn p4_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn p4_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let value3 = Bytes::from("v3");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert!(txn1.get(&key1).is_ok());
             assert!(txn2.get(&key1).is_ok());
@@ -1137,9 +1155,9 @@ mod tests {
             txn1.set(&key1, &value3).unwrap();
             txn2.set(&key1, &value3).unwrap();
 
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -1152,15 +1170,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn p4() {
-        p4_tests(false);
-        p4_tests(true);
+    #[tokio::test]
+    async fn p4() {
+        p4_tests(false).await;
+        p4_tests(true).await;
     }
 
     // G-single: Single Anti-dependency Cycles (read skew)
-    fn g_single_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g_single_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -1170,8 +1188,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
             assert_eq!(txn2.get(&key1).unwrap(), value1.as_ref());
@@ -1179,22 +1197,22 @@ mod tests {
             txn2.set(&key1, &value3).unwrap();
             txn2.set(&key2, &value4).unwrap();
 
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
 
             assert_eq!(txn1.get(&key2).unwrap(), value2.as_ref());
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
         }
     }
 
-    #[test]
-    fn g_single() {
-        g_single_tests(false);
-        g_single_tests(true);
+    #[tokio::test]
+    async fn g_single() {
+        g_single_tests(false).await;
+        g_single_tests(true).await;
     }
 
     // G-single-write-1: Single Anti-dependency Cycles (read skew)
-    fn g_single_write_1_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g_single_write_1_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -1204,8 +1222,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
 
@@ -1218,11 +1236,11 @@ mod tests {
             txn2.set(&key1, &value3).unwrap();
             txn2.set(&key2, &value4).unwrap();
 
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
 
             txn1.delete(&key2).unwrap();
             assert!(txn1.get(&key2).is_err());
-            assert!(match txn1.commit() {
+            assert!(match txn1.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -1235,15 +1253,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn g_single_write_1() {
-        g_single_write_1_tests(false);
-        g_single_write_1_tests(true);
+    #[tokio::test]
+    async fn g_single_write_1() {
+        g_single_write_1_tests(false).await;
+        g_single_write_1_tests(true).await;
     }
 
     // G-single-write-2: Single Anti-dependency Cycles (read skew)
-    fn g_single_write_2_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g_single_write_2_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -1253,8 +1271,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             assert_eq!(txn1.get(&key1).unwrap(), value1.as_ref());
             let range = "k1".as_bytes()..="k2".as_bytes();
@@ -1271,18 +1289,18 @@ mod tests {
 
             drop(txn1);
 
-            txn2.commit().unwrap();
+            txn2.commit().await.unwrap();
         }
     }
 
-    #[test]
-    fn g_single_write_2() {
-        g_single_write_2_tests(false);
-        g_single_write_2_tests(true);
+    #[tokio::test]
+    async fn g_single_write_2() {
+        g_single_write_2_tests(false).await;
+        g_single_write_2_tests(true).await;
     }
 
-    fn g2_item_tests(is_ssi: bool) {
-        let store = create_hermitage_store(is_ssi);
+    async fn g2_item_tests(is_ssi: bool) {
+        let store = create_hermitage_store(is_ssi).await;
 
         let key1 = Bytes::from("k1");
         let key2 = Bytes::from("k2");
@@ -1292,8 +1310,8 @@ mod tests {
         let value4 = Bytes::from("v4");
 
         {
-            let mut txn1 = store.begin().unwrap();
-            let mut txn2 = store.begin().unwrap();
+            let mut txn1 = store.begin().await.unwrap();
+            let mut txn2 = store.begin().await.unwrap();
 
             let range = "k1".as_bytes()..="k2".as_bytes();
             let res = txn1.scan(range.clone()).unwrap();
@@ -1309,9 +1327,9 @@ mod tests {
             txn1.set(&key1, &value3).unwrap();
             txn2.set(&key2, &value4).unwrap();
 
-            txn1.commit().unwrap();
+            txn1.commit().await.unwrap();
 
-            assert!(match txn2.commit() {
+            assert!(match txn2.commit().await {
                 Err(err) => {
                     if let Error::TransactionReadConflict = err {
                         true
@@ -1324,28 +1342,28 @@ mod tests {
         }
     }
 
-    #[test]
-    fn g2_item() {
-        g2_item_tests(false);
-        g2_item_tests(true);
+    #[tokio::test]
+    async fn g2_item() {
+        g2_item_tests(false).await;
+        g2_item_tests(true).await;
     }
 
     fn require_send<T: Send>(_: T) {}
     fn require_sync<T: Sync + Send>(_: T) {}
 
-    #[test]
-    fn is_send_sync() {
+    #[tokio::test]
+    async fn is_send_sync() {
         let (db, _) = create_store(false);
 
-        let txn = db.begin().unwrap();
+        let txn = db.begin().await.unwrap();
         require_send(txn);
 
-        let txn = db.begin().unwrap();
+        let txn = db.begin().await.unwrap();
         require_sync(txn);
     }
 
-    #[test]
-    fn max_transaction_entries_limit_exceeded() {
+    #[tokio::test]
+    async fn max_transaction_entries_limit_exceeded() {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
@@ -1371,7 +1389,7 @@ mod tests {
         let default_value = Bytes::from("default_value".to_string());
 
         // Writing the 6th key should fail
-        let mut txn = store.begin().unwrap();
+        let mut txn = store.begin().await.unwrap();
 
         for (i, key) in keys.iter().enumerate() {
             // Start a new write transaction
@@ -1383,7 +1401,7 @@ mod tests {
         }
     }
 
-    const ENTRIES: usize = 4_000_00;
+    const ENTRIES: usize = 400_000;
     const KEY_SIZE: usize = 24;
     const VALUE_SIZE: usize = 150;
     const RNG_SEED: u64 = 3;
@@ -1428,9 +1446,9 @@ mod tests {
         fastrand::Rng::with_seed(RNG_SEED)
     }
 
-    #[test]
+    #[tokio::test]
     #[ignore]
-    fn insert_large_txn_and_get() {
+    async fn insert_large_txn_and_get() {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
@@ -1439,18 +1457,18 @@ mod tests {
         let store = Store::new(opts.clone()).expect("should create store");
         let mut rng = make_rng();
 
-        let mut txn = store.begin().unwrap();
+        let mut txn = store.begin().await.unwrap();
         for _ in 0..ENTRIES {
             let (key, value) = gen_pair(&mut rng);
             txn.set(&key, &value).unwrap();
         }
-        txn.commit().unwrap();
+        txn.commit().await.unwrap();
         drop(txn);
 
         // Read the keys from the store
         let mut rng = make_rng();
-        let txn = store.begin_with_mode(Mode::ReadOnly).unwrap();
-        for i in 0..ENTRIES {
+        let txn = store.begin_with_mode(Mode::ReadOnly).await.unwrap();
+        for _i in 0..ENTRIES {
             let (key, _) = gen_pair(&mut rng);
             txn.get(&key).unwrap();
         }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -456,7 +456,7 @@ mod tests {
         }
 
         // Drop the store to simulate closing it
-        drop(store);
+        store.close().await.unwrap();
 
         // Create a new Core instance with VariableKey after dropping the previous one
         let mut opts = Options::new();
@@ -1301,8 +1301,8 @@ mod tests {
     fn require_send<T: Send>(_: T) {}
     fn require_sync<T: Sync + Send>(_: T) {}
 
-    #[test]
-    fn is_send_sync() {
+    #[tokio::test]
+    async fn is_send_sync() {
         let (db, _) = create_store(false);
 
         let txn = db.begin().unwrap();

--- a/src/storage/kv/util.rs
+++ b/src/storage/kv/util.rs
@@ -1,5 +1,7 @@
+use bytes::Bytes;
 use chrono::Utc;
 use crc32fast::Hasher as crc32Hasher;
+use sha2::{Digest, Sha256};
 
 /// Calculates the CRC32 hash of a byte array.
 /// It creates a new CRC32 hasher, updates it with the byte array, and finalizes the hash.
@@ -25,4 +27,11 @@ pub(crate) fn now() -> u64 {
     let timestamp = utc_now.timestamp_nanos_opt().unwrap();
     assert!(timestamp > 0);
     timestamp as u64
+}
+
+pub(crate) fn sha256(arg: Bytes) -> Bytes {
+    let mut hasher = Sha256::new();
+    hasher.update(arg);
+    let result = hasher.finalize();
+    Bytes::copy_from_slice(result.as_slice())
 }

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -1887,7 +1887,7 @@ mod tests {
 
         // Test reading from segment after appending
         let mut bs = vec![0; 4];
-        let n = segment.read_at(&mut bs, 11 as u64).expect("should read");
+        let n = segment.read_at(&mut bs, 11_u64).expect("should read");
         assert_eq!(4, n);
         assert_eq!(&[11, 12, 13, 14].to_vec(), &bs[..]);
 
@@ -2226,10 +2226,10 @@ mod tests {
         assert_eq!(&[0, 1, 2, 3].to_vec(), &bs[WAL_RECORD_HEADER_SIZE..]);
 
         // Read remaining empty block
-        const remaining: usize = BLOCK_SIZE - 11;
-        let mut bs = [0u8; remaining];
+        const REMAINING: usize = BLOCK_SIZE - 11;
+        let mut bs = [0u8; REMAINING];
         let bytes_read = buf_reader.read(&mut bs).expect("should read");
-        assert_eq!(bytes_read, remaining);
+        assert_eq!(bytes_read, REMAINING);
 
         // Read second record from the MultiSegmentReader
         let mut bs = [0u8; 11];
@@ -2238,9 +2238,9 @@ mod tests {
         assert_eq!(&[4, 5, 6, 7].to_vec(), &bs[WAL_RECORD_HEADER_SIZE..]);
 
         // Read remaining empty block
-        let mut bs = [0u8; remaining];
+        let mut bs = [0u8; REMAINING];
         let bytes_read = buf_reader.read(&mut bs).expect("should read");
-        assert_eq!(bytes_read, remaining);
+        assert_eq!(bytes_read, REMAINING);
 
         let mut bs = [0u8; 11];
         buf_reader.read(&mut bs).expect_err("should not read");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,4 @@
 pub mod cache;
-pub mod index;
-pub mod kv;
-pub mod log;
+pub(crate) mod index;
+pub(crate) mod kv;
+pub(crate) mod log;


### PR DESCRIPTION
### Description:

This PR introduces asynchronous functionality to the Store. The primary changes include:

- Make transaction commit async
- Refactored the Store to support async operations.
- Make test cases async

The main design change is that the store now pushes the writes to an async channel, and a background thread is consuming it and committing to the append-only log.

Looking into the usage of async aware lock(s).