### PR TITLE
add sync module for tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lru = "0.12.0"
 async-channel = "2.1.1"
 futures = "0.3.30"
 bytes = "1.5.0"
-tokio = { version = "1.36", features = ["rt"] }
+tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.4.0"
 


### PR DESCRIPTION
## Description

This pull request addresses a failing build by adding the sync module to tokio. Details of the failing build can be found [here](https://github.com/surrealdb/surrealkv/actions/runs/7829877141/job/21362732469) failing build.