### PR TITLE
fix: add windows file system support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           default: true
 
       - name: Compile
-        run: cargo build TARGET=${{ matrix.target }}
+        run: cargo build --target=${{ matrix.target }}
 
   ci:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: rustup run --install 1.70 cargo install --force --version 0.14.3 cargo-deny --locked
 
       - name: Compile
-        run: cargo build --all-targets --all-features
+        run: make build
 
       - name: Run tests
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,41 @@ on:
     branches:
       - main
   pull_request:
-  merge_group:
 
 defaults:
   run:
     shell: bash
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        id: rust-cache
+        uses: actions/cache@v3
+        with:
+            path: |
+                ~/.cargo/bin/
+                ~/.cargo/registry/index/
+                ~/.cargo/registry/cache/
+                ~/.cargo/git/db/
+                target/
+            key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '.github/workflows/*.yml') }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.75.0
+          target: ${{ matrix.target }}
+          components: rustfmt, clippy
+          default: true
+
+      - name: Compile
+        run: cargo build TARGET=${{ matrix.target }}
+
   ci:
     strategy:
       matrix:
@@ -48,9 +76,6 @@ jobs:
       - name: Install cargo-deny
         if: steps.rust-cache.outputs.cache-hit != 'true'
         run: rustup run --install 1.70 cargo install --force --version 0.14.3 cargo-deny --locked
-
-      - name: Compile
-        run: make build
 
       - name: Run tests
         run: make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel",
  "bytes",
@@ -1233,6 +1233,8 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e273ebe2c2eaad64b95aaeccbae6b95d0ba235564b062a13b8ef134c5cae9f6a"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,6 @@
 # This command builds the project, including all targets, and generates the documentation.
-.PHONY: build check linux arm-linux windows macos arm-macos doc
-
-build: check linux arm-linux windows macos arm-macos doc
-
-linux:
-	cargo build --target=x86_64-unknown-linux-gnu
-
-arm-linux:
-	cargo build --target=aarch64-unknown-linux-gnu
-
-windows:
-	cargo build --target=x86_64-pc-windows-msvc
-
-macos:
-	cargo build --target=x86_64-apple-darwin
-
-arm-macos:
-	cargo build --target=aarch64-apple-darwin
-
-doc:
+build: check
+	cargo build --all-targets
 	cargo doc
 
 # This command checks the licenses of all dependencies, formats the code, and runs the Clippy linter.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,24 @@
 # This command builds the project, including all targets, and generates the documentation.
-build: check
-	cargo build --all-targets
+.PHONY: build check linux arm-linux windows macos arm-macos doc
+
+build: check linux arm-linux windows macos arm-macos doc
+
+linux:
+	cargo build --target=x86_64-unknown-linux-gnu
+
+arm-linux:
+	cargo build --target=aarch64-unknown-linux-gnu
+
+windows:
+	cargo build --target=x86_64-pc-windows-msvc
+
+macos:
+	cargo build --target=x86_64-apple-darwin
+
+arm-macos:
+	cargo build --target=aarch64-apple-darwin
+
+doc:
 	cargo doc
 
 # This command checks the licenses of all dependencies, formats the code, and runs the Clippy linter.

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io;
 use std::mem;
 use std::num::NonZeroUsize;
-use std::os::unix::fs::PermissionsExt;
+
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -84,7 +84,18 @@ impl Aol {
 
         if let Ok(metadata) = fs::metadata(dir) {
             let mut permissions = metadata.permissions();
-            permissions.set_mode(opts.dir_mode.unwrap_or(0o750));
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                permissions.set_mode(opts.dir_mode.unwrap_or(0o750));
+            }
+
+            #[cfg(windows)]
+            {
+                permissions.set_readonly(false);
+            }
+
             fs::set_permissions(dir, permissions)?;
         }
 


### PR DESCRIPTION
## Issue Description

The nightly builds on sdb [fails](https://github.com/surrealdb/surrealdb/actions/runs/7935647669/job/21669276247) because some of the functions used to open/access file rely on unix crate exclusively. This PR adds support for windows systems as well.