### PR TITLE
fix: reset cursor to eof on append

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
           default: true
 
       - name: Install cargo-deny
-        if: steps.rust-cache.outputs.cache-hit != 'true'
         run: rustup run --install 1.70 cargo install --force --version 0.14.3 cargo-deny --locked
 
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -419,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn append_read_append() {
+    fn append_read_append_read() {
         // Create a temporary directory
         let temp_dir = create_temp_directory();
 

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -378,4 +378,100 @@ mod tests {
         // Test closing segment
         assert!(a.close().is_ok());
     }
+
+    #[test]
+    fn append_and_read_two_blocks() {
+        // Create a temporary directory
+        let temp_dir = create_temp_directory();
+
+        // Create aol options and open a aol file
+        let opts = Options::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Create two slices of bytes of different sizes
+        let data1 = vec![1; 31 * 1024];
+        let data2 = vec![2; 2 * 1024];
+
+        // Append the first data slice to the aol
+        let r1 = a.append(&data1);
+        assert!(r1.is_ok());
+        assert_eq!(31 * 1024, r1.unwrap().1);
+
+        // Append the second data slice to the aol
+        let r2 = a.append(&data2);
+        assert!(r2.is_ok());
+        assert_eq!(2 * 1024, r2.unwrap().1);
+
+        // Read the first data slice back from the aol
+        let mut read_data1 = vec![0; 31 * 1024];
+        let n1 = a.read_at(&mut read_data1, 0).expect("should read");
+        assert_eq!(31 * 1024, n1);
+        assert_eq!(data1, read_data1);
+
+        // Read the second data slice back from the aol
+        let mut read_data2 = vec![0; 2 * 1024];
+        let n2 = a.read_at(&mut read_data2, 31 * 1024).expect("should read");
+        assert_eq!(2 * 1024, n2);
+        assert_eq!(data2, read_data2);
+
+        // Test closing segment
+        assert!(a.close().is_ok());
+    }
+
+    #[test]
+    fn append_read_append() {
+        // Create a temporary directory
+        let temp_dir = create_temp_directory();
+
+        // Create aol options and open a aol file
+        let opts = Options::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Create two slices of bytes of different sizes
+        let data1 = vec![1; 31 * 1024];
+        let data2 = vec![2; 2 * 1024];
+        let data3 = vec![3; 1024];
+        let data4 = vec![4; 1024];
+
+        // Append the first data slice to the aol
+        let r1 = a.append(&data1);
+        assert!(r1.is_ok());
+        assert_eq!(31 * 1024, r1.unwrap().1);
+
+        // Append the second data slice to the aol
+        let r2 = a.append(&data2);
+        assert!(r2.is_ok());
+        assert_eq!(2 * 1024, r2.unwrap().1);
+
+        // Read the first data slice back from the aol
+        let mut read_data1 = vec![0; 31 * 1024];
+        let n1 = a.read_at(&mut read_data1, 0).expect("should read");
+        assert_eq!(31 * 1024, n1);
+        assert_eq!(data1, read_data1);
+
+        // Append the third data slice to the aol
+        let r3 = a.append(&data4);
+        assert!(r3.is_ok());
+        assert_eq!(1024, r3.unwrap().1);
+
+        // Append the third data slice to the aol
+        let r4 = a.append(&data3);
+        assert!(r4.is_ok());
+        assert_eq!(1024, r4.unwrap().1);
+
+        // Read the first data slice back from the aol
+        let mut read_data1 = vec![0; 31 * 1024];
+        let n1 = a.read_at(&mut read_data1, 0).expect("should read");
+        assert_eq!(31 * 1024, n1);
+        assert_eq!(data1, read_data1);
+
+        // Read the second data slice back from the aol
+        let mut read_data2 = vec![0; 2 * 1024];
+        let n2 = a.read_at(&mut read_data2, 31 * 1024).expect("should read");
+        assert_eq!(2 * 1024, n2);
+        assert_eq!(data2, read_data2);
+
+        // Test closing segment
+        assert!(a.close().is_ok());
+    }
 }

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -702,6 +702,8 @@ fn calculate_crc32(record_type: &[u8], data: &[u8]) -> u32 {
     hasher.finalize()
 }
 
+/// Copies elements from `src` into `dest` until either `dest` is full or all elements in `src` have been copied.
+/// Returns the number of elements copied.
 fn copy_slice(dest: &mut [u8], src: &[u8]) -> usize {
     let min_len = dest.len().min(src.len());
 
@@ -712,6 +714,8 @@ fn copy_slice(dest: &mut [u8], src: &[u8]) -> usize {
     min_len
 }
 
+/// Tries to copy `dest.len()` bytes from `src`, starting at `dest_len`, but not more than `src_len`.
+/// Returns the length of `dest`.
 fn copy_into_dest_from_src(dest: &mut [u8], dest_len: usize, src: &[u8], src_len: usize) -> usize {
     let min_len = std::cmp::min(dest.len() - dest_len, src_len);
     dest[dest_len..(min_len + dest_len)].copy_from_slice(&src[..min_len]);

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -702,7 +702,7 @@ fn calculate_crc32(record_type: &[u8], data: &[u8]) -> u32 {
     hasher.finalize()
 }
 
-fn merge_slices(dest: &mut [u8], src: &[u8]) -> usize {
+fn copy_slice(dest: &mut [u8], src: &[u8]) -> usize {
     let min_len = dest.len().min(src.len());
 
     for (d, s) in dest.iter_mut().zip(src.iter()) {
@@ -710,6 +710,12 @@ fn merge_slices(dest: &mut [u8], src: &[u8]) -> usize {
     }
 
     min_len
+}
+
+fn copy_into_dest_from_src(dest: &mut [u8], dest_len: usize, src: &[u8], src_len: usize) -> usize {
+    let min_len = std::cmp::min(dest.len() - dest_len, src_len);
+    dest[dest_len..(min_len + dest_len)].copy_from_slice(&src[..min_len]);
+    dest.len()
 }
 
 fn parse_segment_name(name: &str) -> Result<(u64, Option<String>)> {
@@ -1023,6 +1029,9 @@ impl<const RECORD_HEADER_SIZE: usize> Segment<RECORD_HEADER_SIZE> {
 
         // write_all will write the entire buffer to the file
         // hence ensuring atomic writes to the file
+
+        // Seek to the end of the file before writing because the cursor might have been moved during read
+        self.file.seek(SeekFrom::End(0))?;
         self.file.write_all(&p.buf[p.flushed..p.written])?;
         p.flushed += n;
         self.file_offset += n as u64;
@@ -1093,10 +1102,10 @@ impl<const RECORD_HEADER_SIZE: usize> Segment<RECORD_HEADER_SIZE> {
         if self.is_wal {
             encode_record_header(buf, rec.len(), partial_record, i);
             // Copy the 'partial_record' into the buffer starting from the WAL_RECORD_HEADER_SIZE offset
-            merge_slices(&mut buf[WAL_RECORD_HEADER_SIZE..], partial_record);
+            copy_slice(&mut buf[WAL_RECORD_HEADER_SIZE..], partial_record);
             active_block.written += partial_record.len() + WAL_RECORD_HEADER_SIZE;
         } else {
-            merge_slices(buf, partial_record);
+            copy_slice(buf, partial_record);
             active_block.written += partial_record.len();
         }
 
@@ -1163,7 +1172,7 @@ impl<const RECORD_HEADER_SIZE: usize> Segment<RECORD_HEADER_SIZE> {
             if remaining > 0 {
                 let buf = &self.block.buf
                     [self.block.flushed + boff..self.block.flushed + boff + remaining];
-                merge_slices(bs, buf);
+                copy_into_dest_from_src(bs, n, buf, buf.len());
                 n += remaining;
             }
 
@@ -2362,5 +2371,36 @@ mod tests {
         assert!(sr[0].id == 4);
         assert!(sr[1].id == 6);
         assert!(sr[2].id == 8);
+    }
+
+    #[test]
+    fn test_copy_into_dest_from_src() {
+        // Scenario 1: dest has one byte and rest in src
+        let mut dest = vec![1, 0, 0, 0, 0];
+        let src = vec![2, 3, 4, 5];
+        let dest_len = copy_into_dest_from_src(&mut dest, 1, &src, src.len());
+        assert_eq!(dest_len, 5);
+        assert_eq!(dest, vec![1, 2, 3, 4, 5]);
+
+        // Scenario 2: src is smaller than dest
+        let mut dest = vec![0; 10];
+        let src = vec![1, 2, 3, 4, 5];
+        let dest_len = copy_into_dest_from_src(&mut dest, 0, &src, src.len());
+        assert_eq!(dest_len, 10);
+        assert_eq!(dest, vec![1, 2, 3, 4, 5, 0, 0, 0, 0, 0]);
+
+        // Scenario 3: src is larger than dest
+        let mut dest = vec![0; 5];
+        let src = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let dest_len = copy_into_dest_from_src(&mut dest, 0, &src, src.len());
+        assert_eq!(dest_len, 5);
+        assert_eq!(dest, vec![1, 2, 3, 4, 5]);
+
+        // Scenario 4: dest is already partially filled
+        let mut dest = vec![1, 2, 3, 4, 5, 0, 0, 0, 0, 0];
+        let src = vec![6, 7, 8, 9, 10];
+        let dest_len = copy_into_dest_from_src(&mut dest, 5, &src, src.len());
+        assert_eq!(dest_len, 10);
+        assert_eq!(dest, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
 }


### PR DESCRIPTION
## Description

When the same file handler is being used, once a read happens, the cursor needs to be set to the end of file before appending again to avoid override.