### PR TITLE
chore: block reads on write-only txn and add store restart test

### DIFF
--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     EmptyValue,                         // The value in the record is empty
     ManifestNotFound,                   // The manifest was not found
     MaxTransactionEntriesLimitExceeded, // The maximum number of entries in a transaction was exceeded
+    TransactionWriteOnly,               // The transaction is write-only
     SendError(String),
     ReceiveError(String),
 }
@@ -95,6 +96,7 @@ impl fmt::Display for Error {
             Error::MaxTransactionEntriesLimitExceeded => {
                 write!(f, "Max transaction entries limit exceeded")
             }
+            Error::TransactionWriteOnly => write!(f, "Transaction is write-only"),
             Error::SendError(err) => write!(f, "Send error: {}", err),
             Error::ReceiveError(err) => write!(f, "Receive error: {}", err),
         }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -147,6 +147,11 @@ impl Transaction {
             return Err(Error::EmptyKey);
         }
 
+        // Do not allow reads if it is a write-only transaction
+        if self.mode.is_write_only() {
+            return Err(Error::TransactionWriteOnly);
+        }
+
         // Create a copy of the key.
         let key = Bytes::copy_from_slice(key);
         let hashed_key = sha256(key.clone());


### PR DESCRIPTION
## Description

This PR does the following:

1) Add a test for checking if store reloads after n restarts for durability check on restarts
2) Block reads on write-only transaction