### PR TITLE
fix: track range bounds to detect write skew during range reads for SSI

### DIFF
--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -249,7 +249,7 @@ impl CommitTracker {
             for committed_tx in self.committed_transactions.iter() {
                 if committed_tx.ts > txn.read_ts {
                     for conflict_key in committed_tx.conflict_keys.iter() {
-                        for range in txn.range_bouds.lock().iter() {
+                        for range in txn.read_key_ranges.lock().iter() {
                             if key_in_range(conflict_key, range) {
                                 return true;
                             }

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Reverse,
     collections::BinaryHeap,
+    ops::Bound,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -12,7 +13,7 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use hashbrown::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::Mutex as AsyncMutex;
-use vart::TrieError;
+use vart::{TrieError, VariableSizeKey};
 
 use crate::storage::kv::{
     error::{Error, Result},
@@ -243,6 +244,20 @@ impl CommitTracker {
         if read_set.is_empty() {
             false
         } else {
+            // For each object in the changeset of the already committed transactions, check if it lies
+            // within the predicates of the current transaction.
+            for committed_tx in self.committed_transactions.iter() {
+                if committed_tx.ts > txn.read_ts {
+                    for conflict_key in committed_tx.conflict_keys.iter() {
+                        for range in txn.range_bouds.lock().iter() {
+                            if key_in_range(conflict_key, range) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
             self.committed_transactions
                 .iter()
                 .filter(|committed_txn| committed_txn.ts > txn.read_ts)
@@ -253,6 +268,24 @@ impl CommitTracker {
                 })
         }
     }
+}
+
+fn key_in_range(key: &Bytes, range: &(Bound<VariableSizeKey>, Bound<VariableSizeKey>)) -> bool {
+    let key = VariableSizeKey::from_slice_with_termination(key);
+
+    let start_inclusive = match &range.0 {
+        Bound::Included(start) => key >= *start,
+        Bound::Excluded(start) => key > *start,
+        Bound::Unbounded => true,
+    };
+
+    let end_exclusive = match &range.1 {
+        Bound::Included(end) => key <= *end,
+        Bound::Excluded(end) => key < *end,
+        Bound::Unbounded => true,
+    };
+
+    start_inclusive && end_exclusive
 }
 
 /// Serializable Snapshot Isolation (SSI):

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -88,7 +88,7 @@ pub struct Transaction {
     /// `read_set` is the keys that are read in the transaction from the snapshot. This is used for conflict detection.
     pub(crate) read_set: Mutex<Vec<(Bytes, u64)>>,
 
-    pub(crate) range_bouds: Mutex<Vec<(Bound<VariableSizeKey>, Bound<VariableSizeKey>)>>,
+    pub(crate) read_key_ranges: Mutex<Vec<(Bound<VariableSizeKey>, Bound<VariableSizeKey>)>>,
 
     /// `committed_values_offsets` is the offsets of values in the transaction post commit to the transaction log. This is used to locate the data in the transaction log.
     committed_values_offsets: HashMap<Bytes, usize>,

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -1698,7 +1698,7 @@ mod tests {
         let value3 = Bytes::from("v3");
         let value4 = Bytes::from("v4");
 
-        // concurrent inserts between scans should fail
+        // inserts into read ranges of already-committed transaction(s) should fail
         {
             let mut txn1 = store.begin().unwrap();
             let mut txn2 = store.begin().unwrap();

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -1526,6 +1526,7 @@ mod tests {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(segment_path)
             .expect("should create file");
 
@@ -1556,6 +1557,7 @@ mod tests {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(segment_path)
             .expect("should create file");
 


### PR DESCRIPTION
## Description

This PR addresses the [issue](https://github.com/surrealdb/surrealkv/issues/28) regarding write skews during range reads when using SSI mode for isolation