### PR TITLE
fix: close_reopen test should read inserted data and append in next run

### DIFF
--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -608,16 +608,17 @@ mod tests {
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
 
-        let num_ops = 1000;
+        let num_ops = 10;
 
         for i in 1..=10 {
             // (Re)open the store
             let store = Store::new(opts.clone()).expect("should create store");
 
             // Append num_ops items to the store
-            for j in (num_ops * (i - 1))..(num_ops * i) {
-                let key = format!("key{}", j);
-                let value = format!("value{}", j);
+            for j in 0..num_ops {
+                let key = format!("key{}", (i - 1) * num_ops + j);
+                let value = (i - 1) * num_ops + j;
+                let value = format!("value{}", value);
                 let mut txn = store.begin().unwrap();
                 txn.set(key.as_bytes(), value.as_bytes()).unwrap();
                 txn.commit().await.unwrap();

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -601,36 +601,32 @@ mod tests {
 
     #[tokio::test]
     async fn insert_close_reopen() {
-        for _ in 0..10 {
-            // Create a temporary directory for testing
-            let temp_dir = create_temp_directory();
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
 
-            // Create store options with the test directory
-            let mut opts = Options::new();
-            opts.dir = temp_dir.path().to_path_buf();
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
 
-            // Create a new store instance with VariableKey as the key type
+        let num_ops = 1000;
+
+        for i in 1..=10 {
+            // (Re)open the store
             let store = Store::new(opts.clone()).expect("should create store");
 
-            // Insert 1000 items into the store
-            for i in 0..1000 {
-                let key = format!("key{}", i);
-                let value = format!("value{}", i);
+            // Append num_ops items to the store
+            for j in (num_ops * (i - 1))..(num_ops * i) {
+                let key = format!("key{}", j);
+                let value = format!("value{}", j);
                 let mut txn = store.begin().unwrap();
                 txn.set(key.as_bytes(), value.as_bytes()).unwrap();
                 txn.commit().await.unwrap();
             }
 
-            // Close the store
-            store.close().await.unwrap();
-
-            // Reopen the store
-            let store = Store::new(opts.clone()).expect("should create store");
-
             // Test that the items are still in the store
-            for i in 0..1000 {
-                let key = format!("key{}", i);
-                let value = format!("value{}", i);
+            for j in 0..(num_ops * i) {
+                let key = format!("key{}", j);
+                let value = format!("value{}", j);
                 let value = value.into_bytes();
                 let txn = store.begin().unwrap();
                 let val = txn.get(key.as_bytes()).unwrap().unwrap();

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -616,9 +616,9 @@ mod tests {
 
             // Append num_ops items to the store
             for j in 0..num_ops {
-                let key = format!("key{}", (i - 1) * num_ops + j);
-                let value = (i - 1) * num_ops + j;
-                let value = format!("value{}", value);
+                let id = (i - 1) * num_ops + j;
+                let key = format!("key{}", id);
+                let value = format!("value{}", id);
                 let mut txn = store.begin().unwrap();
                 txn.set(key.as_bytes(), value.as_bytes()).unwrap();
                 txn.commit().await.unwrap();


### PR DESCRIPTION
## Description

This test case ensures that once data is added to skv, upon each reopening, it can successfully read the data and then append to it accordingly without any errors.




