### PR TITLE
chore: update vart version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "async-channel",
  "bytes",
@@ -1232,9 +1232,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d56828f4bc2743d165217540c06f4d24fffae77846b381fa7ec52ddd1cb5adc"
+checksum = "6c07dbb7140d0a8fa046a25eabaaad09f4082076ccb8f157d9fe2b13dc9ae570"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.4.0"
-vart = "0.2.0"
+vart = "0.2.1"
 
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

Update the version of Vart to resolve the sorting issue in Node4 and release an SKV fix.