### PR TITLE
chore: update skv to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-channel",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Description

This PR upgrades the skv version to 0.1.6, and includes the change to keep the store completely in memory