### PR TITLE
chore: remove entries from index when deleted

### DIFF
--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -39,6 +39,18 @@ impl Indexer {
         Ok(())
     }
 
+    pub fn bulk_delete(&mut self, kv_pairs: &mut [VariableSizeKey]) -> Result<()> {
+        kv_pairs.iter_mut().for_each(|kv| {
+            *kv = kv.terminate();
+        });
+
+        for kv in kv_pairs.iter() {
+            self.index.remove(kv)?;
+        }
+
+        Ok(())
+    }
+
     /// Returns the current version of the index.
     pub fn version(&self) -> u64 {
         self.index.version()


### PR DESCRIPTION
## Description

The deleted entries are tracked as tombstone in the vart index. This is unnecessary and leads to waste of memory to keep track of the deleted keys. This PR deletes the entries for keys which have been deleted from the index.