### PR TITLE
feat: disk format change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1146,6 +1146,7 @@ dependencies = [
  "futures",
  "hashbrown",
  "jemallocator",
+ "libc",
  "lru",
  "nanoid",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,12 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -375,6 +390,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.47",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +439,18 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+]
 
 [[package]]
 name = "equivalent"
@@ -432,6 +494,36 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fmmap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099ab52d5329340a3014f60ca91bc892181ae32e752360d07be9295924dcb0b"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "enum_dispatch",
+ "fs4",
+ "memmapix",
+ "parse-display",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs4"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -495,7 +587,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -601,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +795,24 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmapix"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f517ab414225d5f1755bd284d9545bd08a72a3958b3c6384d72e95de9cc1a1d3"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memoffset"
@@ -806,6 +922,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
+dependencies = [
+ "once_cell",
+ "parse-display-derive",
+ "regex",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.47",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +994,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c20af3800cee5134b79a3bd4a3d4b583c16ccfa5f53338f46400851a5b3819"
+checksum = "347e1a588d1de074eeb3c00eadff93db4db65aeb62aee852b1efd0949fe65b6c"
 dependencies = [
  "ahash",
  "equivalent",
@@ -1016,6 +1182,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "revision"
+version = "0.7.0"
+dependencies = [
+ "bincode",
+ "revision-derive",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "revision-derive"
+version = "0.7.0"
+dependencies = [
+ "darling",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,7 +1259,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -1132,6 +1319,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.47",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
+]
+
+[[package]]
 name = "surrealkv"
 version = "0.1.6"
 dependencies = [
@@ -1143,19 +1359,32 @@ dependencies = [
  "crossbeam",
  "crossbeam-channel",
  "fastrand",
+ "fmmap",
  "futures",
  "hashbrown",
  "jemallocator",
  "libc",
  "lru",
+ "memmap2",
  "nanoid",
  "parking_lot",
  "quick_cache",
  "rand 0.8.5",
+ "revision",
  "sha2",
  "tempdir",
  "tokio",
  "vart",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1177,6 +1406,26 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -1216,7 +1465,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
 ]
 
 [[package]]
@@ -1283,7 +1532,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
  "wasm-bindgen-shared",
 ]
 
@@ -1305,7 +1554,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1500,20 +1749,20 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.25"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.25"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.47",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.7.0"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df61cfb2522f24fd6aa90ce3489c2c8660a181075e7bac3ae7bdf22287d238f"
 dependencies = [
  "bincode",
  "revision-derive",
@@ -1194,6 +1196,8 @@ dependencies = [
 [[package]]
 name = "revision-derive"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ff0b6794d4e0aab5e4486870941caefe9f258e63cad2f21b49a6302377c85"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -1482,9 +1486,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c07dbb7140d0a8fa046a25eabaaad09f4082076ccb8f157d9fe2b13dc9ae570"
+checksum = "b9f8fe507a1dd4f78b79e7c3b08232f4a826c6140252d1fc7a0aa4d8b9992211"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
-quick_cache = "0.4.0"
+quick_cache = "0.5.1"
 vart = "0.2.1"
+revision = {path = "/Users/farhan/workspace/surrealdb/revision"}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -40,6 +41,8 @@ jemallocator = "0.5.4"
 nanoid = "0.4.0"
 fastrand = "2.0.1"
 libc = "0.2.155"
+fmmap = "0.3.3"
+memmap2 = "0.9.4"
 
 [[bench]]
 name = "store_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = "0.2.1"
-revision = {path = "/Users/kfarhan/workspace/surrealdb/revision"}
+vart = "0.3.0"
+revision = "0.7.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ sha2 = "0.10.8"
 quick_cache = "0.4.0"
 vart = "0.2.1"
 
-
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 tempdir = "0.3"
@@ -40,6 +39,7 @@ criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 jemallocator = "0.5.4"
 nanoid = "0.4.0"
 fastrand = "2.0.1"
+libc = "0.2.155"
 
 [[bench]]
 name = "store_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ jemallocator = "0.5.4"
 nanoid = "0.4.0"
 fastrand = "2.0.1"
 
-
 [[bench]]
 name = "store_bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
 vart = "0.2.1"
-revision = {path = "/Users/farhan/workspace/surrealdb/revision"}
+revision = {path = "/Users/kfarhan/workspace/surrealdb/revision"}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/benches/io_bench.rs
+++ b/benches/io_bench.rs
@@ -1,0 +1,147 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use libc;
+use rand::Rng;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
+fn create_large_file<P: AsRef<Path>>(path: P, size: u64) -> io::Result<()> {
+    let mut file = OpenOptions::new().create(true).write(true).open(path)?;
+
+    let buffer = vec![0u8; 1024 * 1024]; // 1 MB buffer
+    let mut written = 0;
+
+    while written < size {
+        let to_write = std::cmp::min(size - written, buffer.len() as u64);
+        file.write_all(&buffer[..to_write as usize])?;
+        written += to_write;
+    }
+
+    Ok(())
+}
+
+const ADVICE_RANDOM: i32 = 1;
+const ADVICE_SEQUENTIAL: i32 = 2;
+
+#[cfg(target_os = "macos")]
+fn advise_file(fd: i32, advice: i32) -> io::Result<()> {
+    use libc::{fcntl, F_NOCACHE, F_RDAHEAD};
+    match advice {
+        ADVICE_RANDOM => {
+            // Enable read-ahead
+            unsafe {
+                let result = fcntl(fd, F_NOCACHE, 1);
+                if result == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::from_raw_os_error(result))
+                }
+            }
+        }
+        ADVICE_SEQUENTIAL => {
+            // Disable read-ahead
+            unsafe {
+                let result = fcntl(fd, F_RDAHEAD, 1);
+                if result == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::from_raw_os_error(result))
+                }
+            }
+            // Additionally, you might consider enabling F_NOCACHE to avoid caching reads,
+            // which can be beneficial for random access patterns to prevent cache pollution.
+            // However, use this with caution as it can have other performance implications.
+            // unsafe { fcntl(fd, F_NOCACHE, 1); }
+        }
+        _ => Ok(()), // Handle all other cases without doing anything
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn advise_file(fd: i32, advice: i32) -> io::Result<()> {
+    match advice {
+        ADVICE_RANDOM => {
+            // Enable read-ahead
+            unsafe {
+                let result = libc::posix_fadvise(fd, 0, 0, POSIX_FADV_RANDOM);
+                if result == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::from_raw_os_error(result))
+                }
+            }
+        }
+        ADVICE_SEQUENTIAL => {
+            // Enable read-ahead
+            unsafe {
+                let result = libc::posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+                if result == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::from_raw_os_error(result))
+                }
+            }
+        }
+        _ => Ok(()), // Handle all other cases without doing anything
+    }
+}
+
+fn sequential_read(file: &mut File, buffer: &mut [u8], use_fadvise: bool) -> io::Result<()> {
+    if use_fadvise {
+        advise_file(file.as_raw_fd(), ADVICE_SEQUENTIAL)?;
+    }
+
+    while file.read(buffer)? > 0 {}
+
+    Ok(())
+}
+
+fn random_read(file: &mut File, buffer: &mut [u8], use_fadvise: bool) -> io::Result<()> {
+    let file_size = file.metadata()?.len();
+    let mut rng = rand::thread_rng();
+
+    if use_fadvise {
+        advise_file(file.as_raw_fd(), ADVICE_RANDOM)?;
+    }
+
+    for _ in 0..10000 {
+        // Adjust the number of reads based on your benchmarking needs
+        let offset = rng.gen_range(0..file_size);
+        file.seek(SeekFrom::Start(offset))?;
+        file.read(buffer)?;
+    }
+
+    Ok(())
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("posix_fadvise");
+    let file_path = "large_file.dat";
+    let file_size = 512 * 1024 * 1024;
+    // Create a large file
+    create_large_file(file_path, file_size).unwrap();
+
+    // Open the file for reading
+    let mut file = File::open(file_path).unwrap();
+
+    let mut buffer = vec![0; 4096]; // Adjust buffer size as needed
+
+    group.bench_function("Sequential Read with fadvise", |b| {
+        b.iter(|| sequential_read(&mut file, &mut buffer, true).unwrap())
+    });
+    group.bench_function("Sequential Read without fadvise", |b| {
+        b.iter(|| sequential_read(&mut file, &mut buffer, false).unwrap())
+    });
+    group.bench_function("Random Read with fadvise", |b| {
+        b.iter(|| random_read(&mut file, &mut buffer, true).unwrap())
+    });
+    group.bench_function("Random Read without fadvise", |b| {
+        b.iter(|| random_read(&mut file, &mut buffer, false).unwrap())
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/benches/mmap_bench.rs
+++ b/benches/mmap_bench.rs
@@ -1,0 +1,98 @@
+use bytes::Buf;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fmmap::{MmapFile, MmapFileExt};
+use memmap2::MmapOptions;
+use rand::Rng;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+// Create a large file with random data
+fn create_large_file<P: AsRef<Path>>(path: P, size: usize) -> io::Result<()> {
+    let mut file = File::create(path)?;
+    let mut rng = rand::thread_rng();
+    let mut remaining = size;
+
+    while remaining > 0 {
+        let mut data = [0u8; 1024];
+        rng.fill(&mut data[..]);
+        let to_write = std::cmp::min(1024, remaining);
+        file.write_all(&data[..to_write])?;
+        remaining -= to_write;
+    }
+
+    Ok(())
+}
+
+// Benchmark for normal file read
+fn benchmark_normal_file_read(path: &Path) {
+    let mut file = File::open(path).unwrap();
+    let mut buffer = [0u8; 4096];
+
+    while let Ok(n) = file.read(&mut buffer) {
+        if n == 0 {
+            break;
+        }
+        black_box(&buffer[..n]);
+    }
+}
+
+// Benchmark for mmap file read
+fn benchmark_memmap2_file_read(path: &Path, size: usize) {
+    let file = File::open(path).unwrap();
+    let mut buffer = [0u8; 4096];
+    let mut offset = 0usize; // Initialize offset at 0
+    let mmap = unsafe { MmapOptions::new().map(&file).unwrap() };
+    let mut reader = mmap.reader();
+
+    loop {
+        if offset >= size {
+            break;
+        }
+        let n = reader.read(&mut buffer).unwrap();
+        if n == 0 {
+            break;
+        }
+        black_box(&buffer[..n]);
+        offset += n; // Update offset by the number of bytes read
+    }
+}
+
+// Benchmark for mmap file read
+fn benchmark_fmmap_file_read(path: &Path, size: usize) {
+    let file = MmapFile::open(path).unwrap();
+    let mut buffer = [0u8; 4096];
+    let mut offset = 0usize; // Initialize offset at 0
+
+    loop {
+        if offset >= size {
+            break;
+        }
+        let n = file.read(&mut buffer, offset);
+        if n == 0 {
+            break;
+        }
+        black_box(&buffer[..n]);
+        offset += n; // Update offset by the number of bytes read
+    }
+}
+
+// Criterion benchmark harness
+fn criterion_benchmark(c: &mut Criterion) {
+    let file_path = "large_file.bin";
+    let file_size = 128 * 1024 * 1024; // 128 MB
+    create_large_file(file_path, file_size).unwrap();
+
+    c.bench_function("normal_file_read", |b| {
+        b.iter(|| benchmark_normal_file_read(Path::new(file_path)))
+    });
+    c.bench_function("memmap2_file_read", |b| {
+        b.iter(|| benchmark_memmap2_file_read(Path::new(file_path), file_size))
+    });
+    c.bench_function("fmmap_file_read", |b| {
+        b.iter(|| benchmark_fmmap_file_read(Path::new(file_path), file_size))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -441,7 +441,7 @@ impl ValueRef {
         // If the value is not in the cache, read it from the commit log
         let mut buf = vec![0; self.value_length];
         let clog = self.store.clog.as_ref().unwrap().read();
-        clog.read_at_segment(&mut buf, self.segment_id, value_offset)?;
+        clog.read_at(&mut buf, self.segment_id, value_offset)?;
 
         // Cache the newly read value for future use
         self.store

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -61,9 +61,9 @@ impl Entry {
 //   | tx_id: u64                                              |
 //   | ts: u64                                                 |
 //   | version: u16                                            |
-//   | key: Bytes                                              |
-//   | key_len: u32                                            |
 //   | md: Option<Metadata>                                    |
+//   | key_len: u32                                            |
+//   | key: Bytes                                              |
 //   | value_len: u32                                          |
 //   | value: Bytes                                            |
 //   | crc32: u32                                              |
@@ -73,7 +73,7 @@ impl Entry {
 // Record encoded format:
 //
 //   |----------|----------|------------|-----------------|----------|------------|-----|--------------|-------|-------|
-//   | tx_id(8) |   ts(8)  | version(2) | metadata_len(4) | metadata | key_len(4) | key | value_len(4) | value | crc32 |
+//   | tx_id(8) |   ts(8)  | version(2) | metadata_len(2) | metadata | key_len(4) | key | value_len(4) | value | crc32 |
 //   |----------|----------|------------|-----------------|----------|------------|-----|--------------|-------|-------|
 //
 #[derive(Debug)]

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -116,13 +116,13 @@ impl Records {
     pub(crate) fn encode(
         &self,
         buf: &mut BytesMut,
-        current_offset: u64,
+        // current_offset: u64,
         offset_tracker: &mut HashMap<Bytes, usize>,
     ) -> Result<()> {
         // Encode entries and store offsets
         for entry in &self.entries {
             let mut offset = entry.encode(buf)?;
-            offset += current_offset as usize;
+            // offset += current_offset as usize;
 
             // Store the offset for the current entry
             offset_tracker.insert(entry.key.clone(), offset);
@@ -291,7 +291,7 @@ impl ValueRef {
         key: &Bytes,
         value: &Bytes,
         metadata: Option<&Metadata>,
-        value_offsets: &HashMap<bytes::Bytes, usize>,
+        value_offset: u64,
         max_value_threshold: usize,
     ) -> Bytes {
         let mut buf = BytesMut::new();
@@ -299,14 +299,12 @@ impl ValueRef {
         if value.len() <= max_value_threshold {
             buf.put_u8(1); // swizzle flag to indicate value is inlined or stored in log
             buf.put_u32(value.len() as u32);
-            let val_off = value_offsets.get(key).unwrap();
-            buf.put_u64(*val_off as u64);
+            buf.put_u64(value_offset);
             buf.put(value.as_ref());
         } else {
             buf.put_u8(0);
             buf.put_u32(value.len() as u32);
-            let val_off = value_offsets.get(key).unwrap();
-            buf.put_u64(*val_off as u64);
+            buf.put_u64(value_offset);
         }
 
         if let Some(metadata) = &metadata {

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
     MismatchedSegmentID(u64, u64),
     MaxKeySizeCannotBeDecreased, // The maximum key size cannot be decreased
     MaxValueSizeCannotBeDecreased, // The maximum value size cannot be decreased
+    MaxSegmentSizeCannotBeChanged, // The maximum segment size cannot be changed
 }
 
 /// Error structure for encoding errors
@@ -113,6 +114,9 @@ impl fmt::Display for Error {
             ),
             Error::MaxKeySizeCannotBeDecreased => write!(f, "Max key size cannot be decreased"),
             Error::MaxValueSizeCannotBeDecreased => write!(f, "Max value size cannot be decreased"),
+            Error::MaxSegmentSizeCannotBeChanged => {
+                write!(f, "Max segment size cannot be changed")
+            }
         }
     }
 }

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -37,10 +37,12 @@ pub enum Error {
     TransactionWriteOnly,               // The transaction is write-only
     SendError(String),
     ReceiveError(String),
+    RevisionError(String),
     MismatchedSegmentID(u64, u64),
     MaxKeySizeCannotBeDecreased, // The maximum key size cannot be decreased
     MaxValueSizeCannotBeDecreased, // The maximum value size cannot be decreased
     MaxSegmentSizeCannotBeChanged, // The maximum segment size cannot be changed
+    CompactionInProgress,        // Compaction is in progress
 }
 
 /// Error structure for encoding errors
@@ -117,6 +119,8 @@ impl fmt::Display for Error {
             Error::MaxSegmentSizeCannotBeChanged => {
                 write!(f, "Max segment size cannot be changed")
             }
+            Error::CompactionInProgress => write!(f, "Compaction is in progress"),
+            Error::RevisionError(err) => write!(f, "Revision error: {}", err),
         }
     }
 }
@@ -158,5 +162,11 @@ impl From<async_channel::SendError<std::result::Result<(), Error>>> for Error {
 impl From<async_channel::RecvError> for Error {
     fn from(error: async_channel::RecvError) -> Self {
         Error::ReceiveError(format!("Async channel receive error: {}", error))
+    }
+}
+
+impl From<revision::Error> for Error {
+    fn from(err: revision::Error) -> Self {
+        Error::RevisionError(err.to_string())
     }
 }

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -35,7 +35,7 @@ impl Indexer {
         kv_pairs.iter_mut().for_each(|kv| {
             kv.key = kv.key.terminate();
         });
-        self.index.bulk_insert(kv_pairs)?;
+        self.index.bulk_insert(kv_pairs, true)?;
         Ok(())
     }
 

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -39,6 +39,18 @@ impl Indexer {
         Ok(())
     }
 
+    pub fn bulk_delete(&mut self, kv_pairs: &mut [VariableSizeKey]) -> Result<()> {
+        kv_pairs.iter_mut().for_each(|kv| {
+            *kv = kv.terminate();
+        });
+
+        for kv in kv_pairs.iter() {
+            self.index.remove(kv)?;
+        }
+
+        Ok(())
+    }
+
     /// Returns the current version of the index.
     pub fn version(&self) -> u64 {
         self.index.version()

--- a/src/storage/kv/manifest.rs
+++ b/src/storage/kv/manifest.rs
@@ -1,0 +1,193 @@
+use revision::{revisioned, Revisioned};
+use std::path::Path;
+
+use super::reader::Reader;
+use crate::storage::log::{
+    write_field, Error as LogError, MultiSegmentReader, SegmentRef, BLOCK_SIZE,
+};
+use crate::{Error, Options, Result};
+
+#[revisioned(revision = 1)]
+#[derive(Debug, Clone)]
+pub(crate) enum ManifestChangeType {
+    Options(Options),
+}
+
+#[revisioned(revision = 1)]
+#[derive(Debug, Clone)]
+pub struct Manifest {
+    pub(crate) changes: Vec<ManifestChangeType>,
+}
+
+impl Manifest {
+    pub(crate) fn new() -> Self {
+        Manifest {
+            changes: Vec::new(),
+        }
+    }
+
+    // Append a Manifest to a file containing a Vec<Manifest>
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        self.serialize_revisioned(&mut buf)?;
+        Ok(buf)
+    }
+
+    // Append a Manifest to a file containing a Vec<Manifest>
+    pub fn serialize(&self) -> Result<Vec<u8>> {
+        let mut data = Vec::new();
+        self.serialize_revisioned(&mut data)?;
+
+        let mut buf = Vec::new();
+        write_field(&data, &mut buf).unwrap();
+
+        Ok(buf)
+    }
+
+    pub fn extract_options(&self) -> Vec<Options> {
+        self.changes
+            .iter()
+            .filter_map(|change_op| match change_op {
+                ManifestChangeType::Options(options) => Some(options.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // Extract the last Option, irrespective of the operation type
+    pub fn extract_last_option(&self) -> Option<Options> {
+        self.changes
+            .iter()
+            .filter_map(|change_op| match change_op {
+                ManifestChangeType::Options(options) => Some(options),
+                _ => None,
+            })
+            .cloned()
+            .last()
+    }
+
+    // Create a new manifest with an update change for an option
+    pub fn with_update_option_change(opt: &Options) -> Self {
+        let mut changes = Vec::new();
+        changes.push(ManifestChangeType::Options(opt.clone()));
+
+        Manifest { changes }
+    }
+
+    // Load Vec<Manifest> from a dir
+    pub fn load_from_dir(path: &Path) -> Result<Self> {
+        let mut manifests = Manifest::new();
+        if !path.exists() {
+            return Ok(manifests);
+        }
+
+        let sr = SegmentRef::read_segments_from_directory(path)?;
+        let reader = MultiSegmentReader::new(sr)?;
+        let mut reader = Reader::new_from(reader, 0, BLOCK_SIZE);
+
+        loop {
+            // Read the next transaction record from the log.
+            let mut len_buf = [0; 4];
+            let res = reader.read(&mut len_buf); // Read 4 bytes for the length
+            if let Err(e) = res {
+                if let Error::LogError(LogError::Eof(_)) = e {
+                    break;
+                } else {
+                    return Err(e);
+                }
+            }
+
+            let len = u32::from_be_bytes(len_buf) as usize; // Convert bytes to length
+            let mut md_bytes = vec![0u8; len];
+            reader.read(&mut md_bytes)?; // Read the actual metadata
+
+            let manifest = Manifest::deserialize_revisioned(&mut md_bytes.as_slice())?;
+            manifests.changes.extend(manifest.changes);
+        }
+
+        Ok(manifests)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::log::aof::log::Aol;
+    use crate::storage::log::Options as LogOptions;
+
+    use super::*;
+    use tempdir::TempDir;
+
+    fn create_temp_directory() -> TempDir {
+        TempDir::new("test").unwrap()
+    }
+
+    #[test]
+    fn test_manifest_append_and_load() {
+        // Create a temporary directory
+        let temp_dir = create_temp_directory();
+        let opts = LogOptions::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        let manifest = Manifest {
+            changes: vec![ManifestChangeType::Options(Options::default())],
+        };
+
+        // Append the manifest to the file
+        let buf = manifest.serialize().unwrap();
+        a.append(&buf).expect("should append record");
+        a.close().expect("should close aol");
+
+        // Load the manifests from the file
+        let loaded_manifest = Manifest::load_from_dir(temp_dir.path()).unwrap();
+
+        // Assert that the loaded manifests contain exactly one manifest
+        assert_eq!(loaded_manifest.changes.len(), 1);
+    }
+
+    #[test]
+    fn test_add_and_read_multiple_manifests() {
+        // Step 1: Create a temporary directory
+        let temp_dir = create_temp_directory();
+        let opts = LogOptions::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Step 2: Create the first Manifest instance and append it to the file
+        let first_manifest = Manifest {
+            changes: vec![ManifestChangeType::Options(Options::default())],
+        };
+
+        // Append the manifest to the file
+        let buf = first_manifest.serialize().unwrap();
+        a.append(&buf).expect("should append record");
+
+        // Step 4: Create a new Manifest instance with changes and append it to the same file
+        let mut opt = Options::default();
+        opt.max_entries_per_txn = 1;
+
+        let second_manifest = Manifest {
+            changes: vec![ManifestChangeType::Options(opt)],
+        };
+
+        let buf = second_manifest.serialize().unwrap();
+
+        a.append(&buf).expect("should append record");
+
+        a.close().expect("should close aol");
+
+        // Step 5: Load the manifests from the file
+        let loaded_manifest = Manifest::load_from_dir(temp_dir.path()).unwrap();
+
+        // Step 6: Assert that the loaded manifests contain exactly two manifests
+        assert_eq!(loaded_manifest.changes.len(), 2);
+        let updated_change = loaded_manifest.changes[1].clone();
+
+        match updated_change {
+            ManifestChangeType::Options(options) => {
+                assert_eq!(options.max_entries_per_txn, 1);
+            }
+            _ => {
+                assert!(false, "option change is not of type Update");
+            }
+        }
+    }
+}

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -1,6 +1,7 @@
 pub mod entry;
 pub mod error;
 pub(crate) mod indexer;
+pub(crate) mod manifest;
 pub(crate) mod meta;
 pub mod option;
 pub(crate) mod oracle;

--- a/src/storage/kv/option.rs
+++ b/src/storage/kv/option.rs
@@ -1,35 +1,25 @@
 use std::path::PathBuf;
 
-use crate::storage::{
-    kv::error::{Error, Result},
-    log::Metadata,
-};
+use revision::revisioned;
 
-// Defining constants for metadata keys
-const META_KEY_ISOLATION_LEVEL: &str = "isolation_level";
-const META_KEY_MAX_KEY_SIZE: &str = "max_key_size";
-const META_KEY_MAX_VALUE_SIZE: &str = "max_value_size";
-const META_KEY_MAX_VALUE_THRESHOLD: &str = "max_value_threshold";
-const META_KEY_MAX_ENTRIES_PER_TX: &str = "max_entries_per_txn";
-const META_KEY_MAX_FILE_SIZE: &str = "max_file_size";
-const META_KEY_MAX_VALUE_CACHE_SIZE: &str = "max_value_cache_size";
-
+#[revisioned(revision = 1)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum IsolationLevel {
-    SnapshotIsolation = 1,
-    SerializableSnapshotIsolation = 2,
+    SnapshotIsolation,
+    SerializableSnapshotIsolation,
 }
 
 impl IsolationLevel {
     pub fn from_u64(value: u64) -> Option<Self> {
         match value {
-            1 => Some(IsolationLevel::SnapshotIsolation),
-            2 => Some(IsolationLevel::SerializableSnapshotIsolation),
+            0 => Some(IsolationLevel::SnapshotIsolation),
+            1 => Some(IsolationLevel::SerializableSnapshotIsolation),
             _ => None,
         }
     }
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Options {
     // Required options.
@@ -72,43 +62,6 @@ impl Options {
     pub fn new() -> Self {
         Self::default()
     }
-
-    /// Convert Options to Metadata.
-    pub fn to_metadata(&self) -> Metadata {
-        let mut metadata = Metadata::new(None);
-        metadata.put_uint(META_KEY_ISOLATION_LEVEL, self.isolation_level as u64);
-        metadata.put_uint(META_KEY_MAX_KEY_SIZE, self.max_key_size);
-        metadata.put_uint(META_KEY_MAX_VALUE_SIZE, self.max_value_size);
-        metadata.put_uint(
-            META_KEY_MAX_VALUE_THRESHOLD,
-            self.max_value_threshold as u64,
-        );
-        metadata.put_uint(META_KEY_MAX_ENTRIES_PER_TX, self.max_entries_per_txn as u64);
-        metadata.put_uint(META_KEY_MAX_FILE_SIZE, self.max_segment_size);
-        metadata.put_uint(META_KEY_MAX_VALUE_CACHE_SIZE, self.max_value_cache_size);
-
-        metadata
-    }
-
-    /// Convert Metadata to Options.
-    pub fn from_metadata(metadata: Metadata, dir: PathBuf) -> Result<Self> {
-        let isolation_level =
-            IsolationLevel::from_u64(metadata.get_uint(META_KEY_ISOLATION_LEVEL)?)
-                .ok_or(Error::CorruptedMetadata)?;
-
-        Ok(Options {
-            dir,
-            isolation_level,
-            max_key_size: metadata.get_uint(META_KEY_MAX_KEY_SIZE)?,
-            max_value_size: metadata.get_uint(META_KEY_MAX_VALUE_SIZE)?,
-            max_value_threshold: metadata.get_uint(META_KEY_MAX_VALUE_THRESHOLD)? as usize,
-            max_entries_per_txn: metadata.get_uint(META_KEY_MAX_ENTRIES_PER_TX)? as u32,
-            max_segment_size: metadata.get_uint(META_KEY_MAX_FILE_SIZE)?,
-            max_value_cache_size: metadata.get_uint(META_KEY_MAX_VALUE_CACHE_SIZE)?,
-            disk_persistence: true,
-        })
-    }
-
     /// Returns true if the data should be persisted on disk.
     pub fn should_persist_data(&self) -> bool {
         self.disk_persistence
@@ -133,75 +86,6 @@ mod tests {
         assert_eq!(options.isolation_level, IsolationLevel::SnapshotIsolation);
         assert_eq!(options.max_segment_size, 1 << 29);
         assert_eq!(options.max_value_cache_size, 100000);
-        assert!(options.disk_persistence);
-    }
-
-    #[test]
-    fn options_to_metadata() {
-        let options = Options {
-            dir: PathBuf::from("/test/dir"),
-            max_key_size: 2048,
-            max_value_size: 4096,
-            max_entries_per_txn: 500,
-            max_value_threshold: 128,
-            isolation_level: IsolationLevel::SerializableSnapshotIsolation,
-            max_segment_size: 1 << 25, // 32 MB
-            max_value_cache_size: 200000,
-            disk_persistence: true,
-        };
-
-        let metadata = options.to_metadata();
-
-        assert_eq!(
-            metadata.get_uint(META_KEY_ISOLATION_LEVEL).unwrap(),
-            IsolationLevel::SerializableSnapshotIsolation as u64
-        );
-        assert_eq!(metadata.get_uint(META_KEY_MAX_KEY_SIZE).unwrap(), 2048);
-        assert_eq!(metadata.get_uint(META_KEY_MAX_VALUE_SIZE).unwrap(), 4096);
-        assert_eq!(
-            metadata.get_uint(META_KEY_MAX_VALUE_THRESHOLD).unwrap(),
-            128
-        );
-        assert_eq!(metadata.get_uint(META_KEY_MAX_ENTRIES_PER_TX).unwrap(), 500);
-        assert_eq!(metadata.get_uint(META_KEY_MAX_FILE_SIZE).unwrap(), 1 << 25);
-        assert_eq!(
-            metadata.get_uint(META_KEY_MAX_VALUE_CACHE_SIZE).unwrap(),
-            200000
-        );
-    }
-
-    #[test]
-    fn options_from_metadata() {
-        let mut metadata = Metadata::new(None);
-        metadata.put_uint(
-            META_KEY_ISOLATION_LEVEL,
-            IsolationLevel::SerializableSnapshotIsolation as u64,
-        );
-        metadata.put_uint(META_KEY_MAX_KEY_SIZE, 2048);
-        metadata.put_uint(META_KEY_MAX_VALUE_SIZE, 4096);
-        metadata.put_uint(META_KEY_MAX_VALUE_THRESHOLD, 128);
-        metadata.put_uint(META_KEY_MAX_ENTRIES_PER_TX, 500);
-        metadata.put_uint(META_KEY_MAX_FILE_SIZE, 1 << 25);
-        metadata.put_uint(META_KEY_MAX_VALUE_CACHE_SIZE, 200000);
-
-        let dir = PathBuf::from("/test/dir");
-        let options_result = Options::from_metadata(metadata, dir.clone());
-
-        assert!(options_result.is_ok());
-
-        let options = options_result.unwrap();
-
-        assert_eq!(options.dir, dir);
-        assert_eq!(options.max_key_size, 2048);
-        assert_eq!(options.max_value_size, 4096);
-        assert_eq!(options.max_value_threshold, 128);
-        assert_eq!(options.max_entries_per_txn, 500);
-        assert_eq!(
-            options.isolation_level,
-            IsolationLevel::SerializableSnapshotIsolation
-        );
-        assert_eq!(options.max_segment_size, 1 << 25);
-        assert_eq!(options.max_value_cache_size, 200000);
         assert!(options.disk_persistence);
     }
 }

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -171,6 +171,8 @@ impl RecordReader {
 
     /// Reads a transaction entry.
     fn read_entry_into(&mut self, rec: &mut Record) -> Result<u64> {
+        let entry_crc = self.r.read_uint32()?;
+        let version = self.r.read_uint16()?;
         let id = self.r.read_uint64()?;
 
         // Either the header is corrupted or we have reached the end of the file
@@ -180,7 +182,6 @@ impl RecordReader {
         }
 
         let ts = self.r.read_uint64()?;
-        let version = self.r.read_uint16()?;
 
         let md_len = self.r.read_uint16()? as usize;
         if md_len > MAX_KV_METADATA_SIZE {
@@ -209,7 +210,6 @@ impl RecordReader {
 
         let offset = self.r.offset();
         let v = self.r.read_bytes(v_len)?;
-        let entry_crc = self.r.read_uint32()?;
 
         let actual_crc = calculate_crc32_combined(&k, &v);
         if entry_crc != actual_crc {

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -311,12 +311,12 @@ mod tests {
         // Test appending a non-empty buffer
         let r = a.append(&[0, 1, 2, 3]);
         assert!(r.is_ok());
-        assert_eq!(4, r.unwrap().1);
+        assert_eq!(4, r.unwrap().2);
 
         // Test appending another buffer
         let r = a.append(&[4, 5, 6, 7]);
         assert!(r.is_ok());
-        assert_eq!(4, r.unwrap().1);
+        assert_eq!(4, r.unwrap().2);
 
         a.close().expect("should close aol");
 
@@ -362,7 +362,7 @@ mod tests {
         for i in 0..num_items {
             let r = a.append(&[i; REC_SIZE]); // Each record is a 4-byte array filled with `i`
             assert!(r.is_ok());
-            assert_eq!(REC_SIZE, r.unwrap().1);
+            assert_eq!(REC_SIZE, r.unwrap().2);
         }
 
         a.close().expect("should close aol");

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -258,7 +258,7 @@ impl RecordReader {
     pub(crate) fn read_into(
         &mut self,
         entry: &mut Record,
-    ) -> Result<(HashMap<bytes::Bytes, (u64, usize)>)> {
+    ) -> Result<HashMap<bytes::Bytes, (u64, usize)>> {
         let mut value_offsets = HashMap::new();
         let (segment_id, offset) = self.read_entry_into(entry)?;
         let key = entry.key.clone();

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -312,7 +312,8 @@ mod tests {
 
         // Test initial offset
         let sz = a.offset().unwrap();
-        assert_eq!(0, sz);
+        assert_eq!(0, sz.0);
+        assert_eq!(0, sz.1);
 
         // Test appending a non-empty buffer
         let r = a.append(&[0, 1, 2, 3]);

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -1,20 +1,18 @@
 use std::io::Read;
 
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::BytesMut;
 
 use hashbrown::HashMap;
 
 use crate::storage::{
     kv::{
-        entry::{Record, Records, MAX_KV_METADATA_SIZE},
+        entry::{Record, MAX_KV_METADATA_SIZE},
         error::{Error, Result},
         meta::Metadata,
-        util::calculate_crc32,
+        util::calculate_crc32_combined,
     },
     log::{CorruptionError, Error as LogError, Error::Corruption, MultiSegmentReader},
 };
-
-use super::util::calculate_crc32_combined;
 
 /// `Reader` is a generic reader for reading data from an Aol. It is used
 /// by the `RecordReader` to read data from the Aol source.
@@ -263,7 +261,7 @@ impl RecordReader {
         Ok(value_offsets)
     }
 
-    pub(crate) fn read(&mut self, max_entries: usize) -> Result<(&[u8], u64)> {
+    pub(crate) fn read(&mut self) -> Result<(&[u8], u64)> {
         if let Some(err) = &self.err {
             return Err(err.clone());
         }

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -400,13 +400,13 @@ mod tests {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
-        opts.max_segment_size = 47;
+        opts.max_segment_size = 37;
 
         let keys = vec![Bytes::from("k1"), Bytes::from("k2")];
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 25; // 24bytes is length of header
+        let corruption_offset = 29; // 24bytes is length of header
         corrupt_and_repair(&store, opts.clone(), 2, corruption_offset);
 
         // Close the store
@@ -447,7 +447,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 25; // 24bytes is length of txn header
+        let corruption_offset = 29; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 3, corruption_offset);
 
         // Close the store
@@ -498,7 +498,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 25; // 24bytes is length of txn header
+        let corruption_offset = 29; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 1, corruption_offset);
 
         // Close the store
@@ -545,7 +545,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 25; // 24bytes is length of txn header
+        let corruption_offset = 29; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 3, corruption_offset);
 
         // Close the store
@@ -594,7 +594,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 148 + 25; // 24bytes is length of txn header
+        let corruption_offset = 148 + 29; // 24bytes is length of txn header
         corrupt_at_offset(opts.clone(), 1, corruption_offset);
 
         // Check if a new transaction can be appended post repair
@@ -651,7 +651,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 37 + 25; // 24bytes is length of txn header
+        let corruption_offset = 37 + 29; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 1, corruption_offset);
 
         // Close the store
@@ -693,7 +693,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 37 + 25; // 24bytes is length of txn header
+        let corruption_offset = 37 + 29; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 2, corruption_offset);
 
         // Close the store
@@ -735,7 +735,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 37 + 25; // 24bytes is length of txn header
+        let corruption_offset = 37 + 29; // 24bytes is length of txn header
         corrupt_at_offset(opts.clone(), 3, corruption_offset);
 
         // Close the store

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -161,7 +161,7 @@ fn repair_segment(
 
     let mut count = 0;
     // Read records until the offset marker is reached
-    while let Ok((data, cur_offset)) = reader.read(db_opts.max_entries_per_txn as usize) {
+    while let Ok((data, cur_offset)) = reader.read() {
         if cur_offset >= corrupted_offset_marker {
             break;
         }

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -6,7 +6,7 @@ use crate::storage::{
     kv::{
         error::{Error, Result},
         option::Options,
-        reader::{Reader, TxReader},
+        reader::{Reader, RecordReader},
         util::sanitize_directory,
     },
     log::{aof::log::Aol, Error as LogError, MultiSegmentReader, Segment, SegmentRef, BLOCK_SIZE},
@@ -157,7 +157,7 @@ fn repair_segment(
 
     // Initialize a reader for the segment
     let reader = Reader::new_from(segment_reader, aol.opts.max_file_size, BLOCK_SIZE);
-    let mut reader = TxReader::new(reader, db_opts.max_key_size, db_opts.max_value_size);
+    let mut reader = RecordReader::new(reader, db_opts.max_key_size, db_opts.max_value_size);
 
     let mut count = 0;
     // Read records until the offset marker is reached
@@ -246,7 +246,7 @@ mod tests {
 
     use super::*;
 
-    use crate::storage::kv::entry::TxRecord;
+    use crate::storage::kv::entry::Record;
     use crate::storage::kv::option::Options;
     use crate::storage::kv::store::Store;
     use crate::storage::kv::transaction::Durability;
@@ -354,8 +354,8 @@ mod tests {
             opts.max_segment_size,
             1000,
         );
-        let mut tx_reader = TxReader::new(reader, opts.max_key_size, opts.max_value_size);
-        let mut tx = TxRecord::new(opts.max_entries_per_txn as usize);
+        let mut tx_reader = RecordReader::new(reader, opts.max_key_size, opts.max_value_size);
+        let mut tx = Record::new();
 
         loop {
             tx.reset();

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -406,7 +406,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 17; // 24bytes is length of txn header
+        let corruption_offset = 25; // 24bytes is length of header
         corrupt_and_repair(&store, opts.clone(), 2, corruption_offset);
 
         // Close the store
@@ -435,7 +435,7 @@ mod tests {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
-        opts.max_segment_size = 110;
+        opts.max_segment_size = 74;
 
         let keys = vec![
             Bytes::from("k1"),
@@ -447,7 +447,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 17; // 24bytes is length of txn header
+        let corruption_offset = 25; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 3, corruption_offset);
 
         // Close the store
@@ -498,7 +498,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 17; // 24bytes is length of txn header
+        let corruption_offset = 25; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 1, corruption_offset);
 
         // Close the store
@@ -545,7 +545,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 17; // 24bytes is length of txn header
+        let corruption_offset = 25; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 3, corruption_offset);
 
         // Close the store
@@ -582,6 +582,7 @@ mod tests {
         opts.dir = temp_dir.path().to_path_buf();
         opts.max_segment_size = 470;
 
+        // each record len (37)
         let keys = vec![
             Bytes::from("k1"),
             Bytes::from("k2"),
@@ -593,7 +594,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 220 + 17; // 24bytes is length of txn header
+        let corruption_offset = 148 + 25; // 24bytes is length of txn header
         corrupt_at_offset(opts.clone(), 1, corruption_offset);
 
         // Check if a new transaction can be appended post repair
@@ -636,8 +637,9 @@ mod tests {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
-        opts.max_segment_size = 110;
+        opts.max_segment_size = 74;
 
+        // each record len (37)
         let keys = vec![
             Bytes::from("k1"),
             Bytes::from("k2"),
@@ -649,7 +651,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 47 + 17; // 24bytes is length of txn header
+        let corruption_offset = 37 + 25; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 1, corruption_offset);
 
         // Close the store
@@ -678,7 +680,7 @@ mod tests {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
-        opts.max_segment_size = 110;
+        opts.max_segment_size = 74;
 
         let keys = vec![
             Bytes::from("k1"),
@@ -691,7 +693,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 47 + 17; // 24bytes is length of txn header
+        let corruption_offset = 37 + 25; // 24bytes is length of txn header
         corrupt_and_repair(&store, opts.clone(), 2, corruption_offset);
 
         // Close the store
@@ -720,7 +722,7 @@ mod tests {
         let temp_dir = create_temp_directory();
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
-        opts.max_segment_size = 110;
+        opts.max_segment_size = 74;
 
         let keys = vec![
             Bytes::from("k1"),
@@ -733,7 +735,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let corruption_offset = 47 + 17; // 24bytes is length of txn header
+        let corruption_offset = 37 + 25; // 24bytes is length of txn header
         corrupt_at_offset(opts.clone(), 3, corruption_offset);
 
         // Close the store

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -407,7 +407,7 @@ mod tests {
         let default_value = Bytes::from("val");
 
         let store = setup_store_with_data(opts.clone(), keys, default_value.clone()).await;
-        let expected_keys = vec!["k1", "k2", "k3"];
+        let expected_keys = vec!["k1", "k2", "k3", "k1"];
         for key in expected_keys {
             let key = Bytes::from(key);
 

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -465,32 +465,24 @@ impl Core {
         indexer: &mut Indexer,
     ) -> Result<()> {
         let mut to_insert = Vec::new();
-        let mut to_delete = Vec::new();
+        let (segment_id, val_off) = value_offsets.get(&entry.key).unwrap();
 
-        if let Some(metadata) = entry.metadata.as_ref() {
-            if metadata.deleted() {
-                to_delete.push(entry.key[..].into());
-            }
-            indexer.bulk_delete(&mut to_delete)?;
-        } else {
-            let (segment_id, val_off) = value_offsets.get(&entry.key).unwrap();
+        let index_value = ValueRef::encode(
+            *segment_id,
+            &entry.value,
+            entry.metadata.as_ref(),
+            *val_off as u64,
+            opts.max_value_threshold,
+        );
 
-            let index_value = ValueRef::encode(
-                *segment_id,
-                &entry.value,
-                entry.metadata.as_ref(),
-                *val_off as u64,
-                opts.max_value_threshold,
-            );
+        to_insert.push(KV {
+            key: entry.key[..].into(),
+            value: index_value,
+            version: entry.id,
+            ts: entry.ts,
+        });
 
-            to_insert.push(KV {
-                key: entry.key[..].into(),
-                value: index_value,
-                version: entry.id,
-                ts: entry.ts,
-            });
-            indexer.bulk_insert(&mut to_insert)?;
-        }
+        indexer.bulk_insert(&mut to_insert)?;
 
         Ok(())
     }
@@ -699,17 +691,8 @@ impl Core {
     {
         let mut index = self.indexer.write();
         let mut to_insert = Vec::new();
-        let mut to_delete = Vec::new();
 
         for entry in &task.entries {
-            // If the entry is marked as deleted, add it to the to_delete list.
-            if let Some(metadata) = entry.metadata.as_ref() {
-                if metadata.deleted() {
-                    to_delete.push(entry.key[..].into());
-                    continue;
-                }
-            }
-
             let index_value = encode_entry(entry);
 
             to_insert.push(KV {
@@ -721,7 +704,6 @@ impl Core {
         }
 
         index.bulk_insert(&mut to_insert)?;
-        index.bulk_delete(&mut to_delete)?;
 
         Ok(())
     }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -376,7 +376,7 @@ impl Transaction {
             if val_ref.ts() <= self.read_ts {
                 self.read_set.lock().push((
                     Bytes::copy_from_slice(&key[..&key.len() - 1]), // the keys in the vart leaf are terminated with a null byte
-                    val_ref.ts,
+                    val_ref.ts(),
                 ));
             }
 

--- a/src/storage/kv/util.rs
+++ b/src/storage/kv/util.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 /// Calculates the CRC32 hash of a byte array.
 /// It creates a new CRC32 hasher, updates it with the byte array, and finalizes the hash.
 /// It returns the hash as a 32-bit unsigned integer.
+#[allow(unused)]
 pub(crate) fn calculate_crc32(buf: &[u8]) -> u32 {
     let mut hasher = crc32Hasher::new();
     hasher.update(buf);

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -249,12 +249,12 @@ impl Aol {
         Ok(())
     }
 
-    pub fn rotate(&mut self) -> Result<()> {
+    pub fn rotate(&mut self) -> Result<u64> {
         let _lock = self.mutex.lock();
         self.active_segment.close()?;
         self.active_segment_id += 1;
         self.active_segment = Segment::open(&self.dir, self.active_segment_id, &self.opts)?;
-        Ok(())
+        Ok(self.active_segment_id)
     }
 
     // Returns the current offset within the segment.

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -166,11 +166,9 @@ impl Aol {
             }
         };
 
-        let (off, _) = result.unwrap();
-        // // Calculate offset only for the first chunk of data
-        // let offset = off + self.calculate_offset();
+        let (offset, _) = result.unwrap();
 
-        Ok((self.active_segment_id, off, rec.len()))
+        Ok((self.active_segment_id, offset, rec.len()))
     }
 
     /// Flushes and syncs the active segment.
@@ -309,6 +307,7 @@ impl Drop for Aol {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::Rng;
     use tempdir::TempDir;
 
     fn create_temp_directory() -> TempDir {
@@ -588,5 +587,206 @@ mod tests {
         assert_eq!(1, segment_id);
         assert_eq!(512, offset);
         assert_eq!(1, a.active_segment_id);
+    }
+
+    #[test]
+    fn append_records_across_two_files_and_read() {
+        // Create a temporary directory
+        let temp_dir = create_temp_directory();
+
+        // Create AOL options with a small max file size to force a new file creation on overflow
+        let opts = Options {
+            max_file_size: 1024, // Small enough to ensure the second append creates a new file
+            ..Default::default()
+        };
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Append a record that fits within the first file
+        let first_record = vec![1; 512];
+        a.append(&first_record)
+            .expect("first append should succeed");
+        let (first_segment_id, first_offset) = a.offset().unwrap();
+        assert_eq!(0, first_segment_id);
+        assert_eq!(512, first_offset);
+
+        // Append another record that causes a new file (segment) to be created
+        let second_record = vec![2; 1024]; // This will exceed the max_file_size
+        a.append(&second_record)
+            .expect("second append should succeed");
+        let (second_segment_id, second_offset) = a.offset().unwrap();
+        assert_eq!(1, second_segment_id); // Expecting a new segment/file
+        assert_eq!(1024, second_offset);
+
+        // Read back the first record using its segment ID and offset
+        let mut read_buf = vec![0; 512];
+        a.read_at(&mut read_buf, first_segment_id, 0) // Start at offset 0 of the first segment
+            .expect("failed to read first record");
+        assert_eq!(first_record, read_buf, "First record data mismatch");
+
+        // Read back the second record using its segment ID and offset
+        let mut read_buf = vec![0; 1024];
+        a.read_at(&mut read_buf, second_segment_id, 0) // Start at offset 0 of the second segment
+            .expect("failed to read second record");
+        assert_eq!(second_record, read_buf, "Second record data mismatch");
+    }
+
+    #[test]
+    fn read_beyond_current_offset_should_fail() {
+        // Setup: Create a temporary directory and initialize the log with default options
+        let temp_dir = create_temp_directory();
+        let opts = Options::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Append a single record to ensure there is some data in the log
+        let record = vec![1; 512];
+        a.append(&record).expect("append should succeed");
+
+        // Attempt to read beyond the current offset
+        let mut read_buf = vec![0; 1024]; // Buffer size is larger than the appended record
+        let result = a.read_at(&mut read_buf, 0, 1024); // Attempt to read at an offset beyond the single appended record
+
+        // Verify: The read operation should fail or return an error indicating the offset is out of bounds
+        assert!(
+            result.is_err(),
+            "Reading beyond the current offset should fail"
+        );
+    }
+
+    #[test]
+    fn append_after_reopening_log() {
+        // Setup: Create a temporary directory and initialize the log
+        let temp_dir = create_temp_directory();
+        let opts = Options::default();
+        let record = vec![1; 512];
+
+        // Step 1: Open the log, append a record, and then close it
+        {
+            let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+            a.append(&record).expect("append should succeed");
+        } // Log is closed here as `a` goes out of scope
+
+        // Step 2: Reopen the log and append another record
+        {
+            let mut a = Aol::open(temp_dir.path(), &opts).expect("should reopen aol");
+            a.append(&record)
+                .expect("append after reopen should succeed");
+
+            // Verify: Ensure the log contains both records by reading them back
+            let mut read_buf = vec![0; 512];
+            a.read_at(&mut read_buf, 0, 0)
+                .expect("failed to read first record after reopen");
+            assert_eq!(record, read_buf, "First record data mismatch after reopen");
+
+            a.read_at(&mut read_buf, 0, 512)
+                .expect("failed to read second record after reopen");
+            assert_eq!(record, read_buf, "Second record data mismatch after reopen");
+        }
+    }
+
+    #[test]
+    fn append_across_two_files_and_read() {
+        // Setup: Create a temporary directory and initialize the log with small max file size
+        let temp_dir = create_temp_directory();
+        let opts = Options {
+            max_file_size: 512, // Set max file size to 512 bytes to force new file creation on second append
+            ..Default::default()
+        };
+        let record = vec![1; 512]; // Each record is 512 bytes
+
+        // Step 1: Open the log, append a record, and then close it
+        {
+            let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+            a.append(&record).expect("first append should succeed");
+            a.append(&record).expect("first append should succeed");
+        } // Log is closed here as `a` goes out of scope
+
+        // Step 2: Reopen the log and append another record, which should create a new file
+        {
+            let mut a = Aol::open(temp_dir.path(), &opts).expect("should reopen aol");
+
+            // Verify: Ensure the first record is in a new file by reading it back
+            let mut read_buf = vec![0; 512];
+            // The first record should be at the start of the first file (segment), hence segment_id = 1 and offset = 0.
+            a.read_at(&mut read_buf, 0, 0)
+                .expect("failed to read first record from new file");
+            assert_eq!(record, read_buf, "Record data mismatch in first file");
+
+            // Verify: Ensure the second record is in a new file by reading it back
+            let mut read_buf = vec![0; 512];
+            // The second record should be at the start of the second file (segment), hence segment_id = 1 and offset = 0.
+            a.read_at(&mut read_buf, 1, 0)
+                .expect("failed to read second record from new file");
+            assert_eq!(record, read_buf, "Record data mismatch in second file");
+
+            a.append(&record).expect("first append should succeed");
+            // Verify: Ensure the third record is in a new file by reading it back
+
+            let mut read_buf = vec![0; 512];
+            // The third record should be at the start of the third file (segment), hence segment_id = 1 and offset = 0.
+            a.read_at(&mut read_buf, 2, 0)
+                .expect("failed to read third record from new file");
+            assert_eq!(record, read_buf, "Record data mismatch in third file");
+        }
+    }
+
+    // TODO: add to benchmarks
+    #[test]
+    fn sequential_read_performance() {
+        let temp_dir = create_temp_directory();
+        let opts = Options::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Append 1000 records to ensure we have enough data
+        let record = vec![1; 512]; // Each record is 512 bytes
+        for _ in 0..1000 {
+            a.append(&record).expect("append should succeed");
+        }
+
+        let start_time = std::time::Instant::now();
+
+        // Sequentially read all records
+        let mut read_buf = vec![0; 512];
+        for offset in (0..512000).step_by(512) {
+            a.read_at(&mut read_buf, 0, offset as u64)
+                .expect("failed to read record");
+        }
+
+        let duration = start_time.elapsed();
+
+        println!("Sequential read of 1000 records took: {:?}", duration);
+    }
+
+    // TODO: add to benchmarks
+    #[test]
+    fn random_access_read_performance() {
+        let temp_dir = create_temp_directory();
+        let opts = Options::default();
+        let mut a = Aol::open(temp_dir.path(), &opts).expect("should create aol");
+
+        // Append 1000 records to ensure we have enough data
+        let record = vec![1; 512]; // Each record is 512 bytes
+        for _ in 0..1000 {
+            a.append(&record).expect("append should succeed");
+        }
+
+        // Generate a list of random offsets within the range of the data written
+        let mut offsets = (0..1000)
+            .map(|_| rand::thread_rng().gen_range(0..1000) * 512)
+            .collect::<Vec<u64>>();
+        offsets.sort_unstable();
+        offsets.dedup();
+
+        let start_time = std::time::Instant::now();
+
+        // Randomly read records based on the generated offsets
+        let mut read_buf = vec![0; 512];
+        for offset in offsets {
+            a.read_at(&mut read_buf, 0, offset)
+                .expect("failed to read record");
+        }
+
+        let duration = start_time.elapsed();
+
+        println!("Random access read of 1000 records took: {:?}", duration);
     }
 }

--- a/src/storage/log/aof/log.rs
+++ b/src/storage/log/aof/log.rs
@@ -293,11 +293,6 @@ impl Aol {
             Err(e) => match e {
                 Error::Eof(n) => {
                     return Err(Error::Eof(n));
-                    // if n > 0 {
-                    //     continue;
-                    // } else {
-                    //     return Err(Error::Eof(n));
-                    // }
                 }
                 _ => return Err(e),
             },
@@ -338,6 +333,14 @@ impl Aol {
         Ok(())
     }
 
+    pub fn rotate(&mut self) -> Result<()> {
+        let _lock = self.mutex.lock();
+        self.active_segment.close()?;
+        self.active_segment_id += 1;
+        self.active_segment = Segment::open(&self.dir, self.active_segment_id, &self.opts)?;
+        Ok(())
+    }
+
     // Returns the current offset within the segment.
     pub fn offset(&self) -> Result<u64> {
         // Lock the mutex to ensure thread safety
@@ -351,18 +354,6 @@ impl Aol {
 
         // Add the calculated offset to the offset of the active segment
         Ok(base_offset + active_segment_offset)
-    }
-
-    // Returns the current offset within the segment.
-    pub fn segment_offset(&self) -> Result<(u64, u64)> {
-        // Lock the mutex to ensure thread safety
-        let _lock = self.mutex.lock();
-
-        // Get the offset of the active segment
-        let active_segment_offset = self.active_segment.offset();
-
-        // Add the calculated offset to the offset of the active segment
-        Ok((self.active_segment_id, active_segment_offset))
     }
 
     pub fn size(&self) -> Result<u64> {

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -2566,4 +2566,82 @@ mod tests {
         // Should not have overwritten the data in the file
         assert_eq!(new_content, "Hello, world! More content.");
     }
+
+    #[test]
+    fn append_mode_seek_and_write() {
+        let path = PathBuf::from("test_append_mode.txt");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+
+        // Write initial content
+        file.write(b"Line 1\n").unwrap();
+        file.write(b"Line 2\n").unwrap();
+
+        // Seek to the beginning of the file and attempt to write
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write(b"Line 3\n").unwrap();
+
+        // Read back the file content
+        let mut content = String::new();
+        file.seek(SeekFrom::Start(0)).unwrap(); // Seek back to start to read
+        file.read_to_string(&mut content).unwrap();
+
+        // Clean up
+        std::fs::remove_file(&path).unwrap();
+
+        // Check that "Line 3" was appended at the end, despite the seek
+        assert!(content.ends_with("Line 3\n"));
+    }
+
+    #[test]
+    fn non_append_mode_seek_and_write() {
+        let path = PathBuf::from("test_non_append_mode.txt");
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .read(true)
+            .open(&path)
+            .unwrap();
+
+        // Write initial content
+        file.write(b"Line 1\n").unwrap();
+        file.write(b"Line 2\n").unwrap();
+
+        // Seek to the beginning of the file and attempt to write
+        file.seek(SeekFrom::Start(0)).unwrap();
+        file.write(b"Line 3\n").unwrap();
+
+        // Read back the file content
+        let mut content = String::new();
+        file.seek(SeekFrom::Start(0)).unwrap(); // Seek back to start to read
+        file.read_to_string(&mut content).unwrap();
+
+        // Clean up
+        std::fs::remove_file(&path).unwrap();
+
+        // Check that "Line 3" was written at the beginning, not appended
+        assert!(content.starts_with("Line 3\n"));
+    }
+
+    #[test]
+    fn test_list_segment_ids() {
+        // Create a temporary directory
+        let temp_dir = TempDir::new("test").expect("should create temp dir");
+        let dir_path = temp_dir.path();
+
+        // Populate the directory with segment files and some other files
+        create_segment_file(dir_path, &segment_name(1, ""));
+        create_segment_file(dir_path, &segment_name(2, ""));
+        create_segment_file(dir_path, &segment_name(10, ""));
+
+        // Call the function under test
+        let segment_ids = list_segment_ids(dir_path).unwrap();
+
+        // Verify the output
+        assert_eq!(segment_ids, vec![1, 2, 10]);
+    }
 }


### PR DESCRIPTION
## Description

This is a breaking change to change disk format to make compaction easy. The current disk format is like this

Tx struct encoded format:

+--------------------------------------------------+
| Tx (Transaction)                                |
|--------------------------------------------------|
| header: TxHeader                                |
| entries: Vec<TxEntry>                           |
| crc: u32                                        |
+--------------------------------------------------+

+--------------------------------------------------+
| TxHeader                                        |
|--------------------------------------------------|
| id: u64                                         |
| ts: u64                                         |
| version: u16                                    |
| num_entries: u16                                |
| metadata: Option<Metadata>                      |
+--------------------------------------------------+

+--------------------------------------------------+
| TxEntry                                         |
|--------------------------------------------------|
| key: Bytes                                      |
| key_len: u32                                    |
| md: Option<Metadata>                            |
| value_len: u32                                  |
| value: Bytes                                    |
| crc32: u32                                      |
+--------------------------------------------------+

Doing compaction on this becomes hard, because each entry cannot be read individually to compact and merge. The new proposed format is simple.

Record encoded format:

+---------------------------------------------------------+
| Record                                                  |
|---------------------------------------------------------|
| crc32: u32                                              |
| version: u16                                            |
| tx_id: u64                                              |
| ts: u64                                                 |
| md: Option<Metadata>                                    |
| key_len: u32                                            |
| key: Bytes                                              |
| value_len: u32                                          |
| value: Bytes                                            |
+---------------------------------------------------------+

Record encoded format:
```
+----------+------------+------------+----------+-----------------+------------+------------+------+--------------+-------+
| crc32(4) | version(2) |  tx_id(8)  |  ts(8)   | metadata_len(2) |  metadata  | key_len(4) | key  | value_len(4) | value |
+----------+------------+------------+----------+-----------------+------------+------------+------+--------------+-------+
```
This will make it easy to read each entry and do compaction