### PR TITLE
Chore/release 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-channel",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,8 +1487,6 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f8fe507a1dd4f78b79e7c3b08232f4a826c6140252d1fc7a0aa4d8b9992211"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.3.0"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858e0a7c88fd62d483dd906e2ae63f8601939204cac227cb31dac6b530616ac8"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = "0.3.0"
+vart = {path = "/Users/farhan/workspace/surrealdb/vart"}
 revision = "0.7.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = {path = "/Users/farhan/workspace/surrealdb/vart"}
+vart = "0.3.1"
 revision = "0.7.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -12,7 +12,7 @@ use crate::storage::{
 };
 
 pub(crate) const MD_SIZE: usize = 1; // Size of txmdLen and kvmdLen in bytes
-pub(crate) const MAX_KV_METADATA_SIZE: usize = 1; // Maximum size of key-value metadata in bytes
+pub(crate) const MAX_KV_METADATA_SIZE: usize = 2; // Maximum size of key-value metadata in bytes
 pub(crate) const RECORD_VERSION: u16 = 1; // Version of the transaction header
 
 #[derive(Debug, Clone)]
@@ -50,7 +50,7 @@ impl Entry {
 
     pub(crate) fn is_deleted(&self) -> bool {
         if let Some(metadata) = &self.metadata {
-            metadata.deleted()
+            metadata.is_deleted_or_tombstone()
         } else {
             false
         }

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -48,7 +48,14 @@ impl Entry {
         self.metadata.as_mut().unwrap().as_deleted(true).unwrap();
     }
 
-    pub(crate) fn is_deleted(&self) -> bool {
+    pub(crate) fn mark_tombstone(&mut self) {
+        if self.metadata.is_none() {
+            self.metadata = Some(Metadata::new());
+        }
+        self.metadata.as_mut().unwrap().as_tombstone(true).unwrap();
+    }
+
+    pub(crate) fn is_deleted_or_tombstone(&self) -> bool {
         if let Some(metadata) = &self.metadata {
             metadata.is_deleted_or_tombstone()
         } else {

--- a/src/storage/kv/meta.rs
+++ b/src/storage/kv/meta.rs
@@ -77,6 +77,16 @@ impl Metadata {
         Ok(())
     }
 
+    pub(crate) fn as_tombstone(&mut self, tombstone: bool) -> Result<()> {
+        if tombstone {
+            self.attributes.insert(Attribute::Tombstone);
+        } else {
+            self.attributes.remove(&Attribute::Tombstone);
+        }
+
+        Ok(())
+    }
+
     /// Checks if the 'deleted' attribute is present.
     pub(crate) fn is_deleted(&self) -> bool {
         self.attributes.contains(&Attribute::Deleted)

--- a/src/storage/kv/mod.rs
+++ b/src/storage/kv/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod oracle;
 pub(crate) mod reader;
 pub(crate) mod repair;
 pub mod snapshot;
+pub(crate) mod stats;
 pub mod store;
 pub mod transaction;
 pub(crate) mod util;

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -96,7 +96,7 @@ pub(crate) trait FilterFn {
 fn ignore_deleted(val_ref: &ValueRef, _: u64) -> Result<()> {
     let md = val_ref.metadata();
     if let Some(md) = md {
-        if md.deleted() {
+        if md.is_deleted_or_tombstone() {
             return Err(Error::IndexError(TrieError::KeyNotFound));
         }
     }

--- a/src/storage/kv/stats.rs
+++ b/src/storage/kv/stats.rs
@@ -20,10 +20,12 @@ impl CompactionStats {
         self.records_added.fetch_add(1, Ordering::SeqCst);
     }
 
+    #[allow(unused)]
     pub(crate) fn delete_record(&self) {
         self.records_deleted.fetch_add(1, Ordering::SeqCst);
     }
 
+    #[allow(unused)]
     pub(crate) fn add_tombstone(&self) {
         self.tombstones.fetch_add(1, Ordering::SeqCst);
     }
@@ -32,6 +34,7 @@ impl CompactionStats {
         self.records_deleted.fetch_add(n, Ordering::SeqCst);
     }
 
+    #[allow(unused)]
     pub(crate) fn add_multiple_records(&self, n: u64) {
         self.records_added.fetch_add(n, Ordering::SeqCst);
     }
@@ -44,14 +47,17 @@ impl CompactionStats {
     }
 
     // Getters
+    #[allow(unused)]
     pub(crate) fn get_records_added(&self) -> u64 {
         self.records_added.load(Ordering::SeqCst)
     }
 
+    #[allow(unused)]
     pub(crate) fn get_records_deleted(&self) -> u64 {
         self.records_deleted.load(Ordering::SeqCst)
     }
 
+    #[allow(unused)]
     pub(crate) fn get_tombstones(&self) -> u64 {
         self.tombstones.load(Ordering::SeqCst)
     }
@@ -72,14 +78,17 @@ impl StorageStats {
     }
 
     // Methods to interact with keys_deleted and tombstone_count
+    #[allow(unused)]
     pub(crate) fn key_deleted(&self) {
         self.keys_deleted.fetch_add(1, Ordering::SeqCst);
     }
 
+    #[allow(unused)]
     pub(crate) fn tombstone_counted(&self) {
         self.tombstone_count.fetch_add(1, Ordering::SeqCst);
     }
 
+    #[allow(unused)]
     pub(crate) fn reset(&self) {
         self.compaction_stats.reset();
         self.keys_deleted.store(0, Ordering::SeqCst);

--- a/src/storage/kv/stats.rs
+++ b/src/storage/kv/stats.rs
@@ -1,0 +1,88 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub(crate) struct CompactionStats {
+    records_added: AtomicU64,
+    records_deleted: AtomicU64,
+    tombstones: AtomicU64,
+}
+
+impl CompactionStats {
+    pub(crate) fn new() -> Self {
+        CompactionStats {
+            records_added: AtomicU64::new(0),
+            records_deleted: AtomicU64::new(0),
+            tombstones: AtomicU64::new(0),
+        }
+    }
+
+    // Setters
+    pub(crate) fn add_record(&self) {
+        self.records_added.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn delete_record(&self) {
+        self.records_deleted.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn add_tombstone(&self) {
+        self.tombstones.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn add_multiple_deleted_records(&self, n: u64) {
+        self.records_deleted.fetch_add(n, Ordering::SeqCst);
+    }
+
+    pub(crate) fn add_multiple_records(&self, n: u64) {
+        self.records_added.fetch_add(n, Ordering::SeqCst);
+    }
+
+    // Reset
+    pub(crate) fn reset(&self) {
+        self.records_added.store(0, Ordering::SeqCst);
+        self.records_deleted.store(0, Ordering::SeqCst);
+        self.tombstones.store(0, Ordering::SeqCst);
+    }
+
+    // Getters
+    pub(crate) fn get_records_added(&self) -> u64 {
+        self.records_added.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn get_records_deleted(&self) -> u64 {
+        self.records_deleted.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn get_tombstones(&self) -> u64 {
+        self.tombstones.load(Ordering::SeqCst)
+    }
+}
+pub(crate) struct StorageStats {
+    pub(crate) compaction_stats: CompactionStats,
+    pub(crate) keys_deleted: AtomicU64,
+    pub(crate) tombstone_count: AtomicU64,
+}
+
+impl StorageStats {
+    pub(crate) fn new() -> Self {
+        StorageStats {
+            compaction_stats: CompactionStats::new(),
+            keys_deleted: AtomicU64::new(0),
+            tombstone_count: AtomicU64::new(0),
+        }
+    }
+
+    // Methods to interact with keys_deleted and tombstone_count
+    pub(crate) fn key_deleted(&self) {
+        self.keys_deleted.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn tombstone_counted(&self) {
+        self.tombstone_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn reset(&self) {
+        self.compaction_stats.reset();
+        self.keys_deleted.store(0, Ordering::SeqCst);
+        self.tombstone_count.store(0, Ordering::SeqCst);
+    }
+}

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -450,10 +450,12 @@ impl Core {
         value_offsets: &HashMap<Bytes, (u64, usize)>,
         indexer: &mut Indexer,
     ) -> Result<()> {
-        if let Some(metadata) = entry.metadata.as_ref() {
-            if metadata.is_deleted() {
-                indexer.delete(&mut entry.key[..].into())?;
-            }
+        if entry
+            .metadata
+            .as_ref()
+            .map_or(false, |metadata| metadata.is_deleted())
+        {
+            indexer.delete(&mut entry.key[..].into())?;
         } else {
             let (segment_id, val_off) = value_offsets.get(&entry.key).unwrap();
 

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -448,7 +448,7 @@ impl Core {
         indexer: &mut Indexer,
     ) -> Result<()> {
         if let Some(metadata) = entry.metadata.as_ref() {
-            if metadata.deleted() {
+            if metadata.is_deleted() {
                 indexer.delete(&mut entry.key[..].into())?;
             }
         } else {
@@ -681,16 +681,15 @@ impl Core {
     {
         let mut index = self.indexer.write();
         let mut to_insert = Vec::new();
-        // let mut to_delete = Vec::new();
 
         for entry in &task.entries {
-            // If the entry is marked as deleted, add it to the to_delete list.
-            // if let Some(metadata) = entry.metadata.as_ref() {
-            //     if metadata.deleted() {
-            //         to_delete.push(entry.key[..].into());
-            //         continue;
-            //     }
-            // }
+            // If the entry is marked as deleted, delete it.
+            if let Some(metadata) = entry.metadata.as_ref() {
+                if metadata.is_deleted() {
+                    index.delete(&mut entry.key[..].into())?;
+                    continue;
+                }
+            }
 
             let index_value = encode_entry(entry);
 
@@ -703,7 +702,6 @@ impl Core {
         }
 
         index.bulk_insert(&mut to_insert)?;
-        // index.bulk_delete(&mut to_delete)?;
 
         Ok(())
     }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -29,6 +29,7 @@ use crate::storage::{
         oracle::Oracle,
         reader::{Reader, RecordReader},
         repair::{repair_last_corrupted_segment, restore_repair_files},
+        stats::StorageStats,
         transaction::{Durability, Mode, Transaction},
     },
     log::{
@@ -43,6 +44,7 @@ pub(crate) struct StoreInner {
     pub(crate) is_compacting: AtomicBool,
     stop_tx: Sender<()>,
     task_runner_handle: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
+    pub(crate) stats: Arc<StorageStats>,
 }
 
 // Inner representation of the store. The wrapper will handle the asynchronous closing of the store.
@@ -64,6 +66,7 @@ impl StoreInner {
             is_closed: AtomicBool::new(false),
             is_compacting: AtomicBool::new(false),
             task_runner_handle: Arc::new(AsyncMutex::new(Some(task_runner_handle))),
+            stats: Arc::new(StorageStats::new()),
         })
     }
 

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -165,7 +165,7 @@ impl Transaction {
         Ok(())
     }
 
-    // Delete all the versions of a key.
+    // Delete all the versions of a key. This is a hard delete.
     pub fn delete(&mut self, key: &[u8]) -> Result<()> {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);
@@ -174,7 +174,7 @@ impl Transaction {
         Ok(())
     }
 
-    /// Clear the key but not delete it.
+    /// Clear the key but not delete it. This is a soft delete.
     pub fn clear(&mut self, key: &[u8]) -> Result<()> {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -165,11 +165,20 @@ impl Transaction {
         Ok(())
     }
 
-    /// Deletes a key from the store.
+    // Delete all the versions of a key.
     pub fn delete(&mut self, key: &[u8]) -> Result<()> {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);
         entry.mark_delete();
+        self.write(entry)?;
+        Ok(())
+    }
+
+    /// Clear the key but not delete it.
+    pub fn clear(&mut self, key: &[u8]) -> Result<()> {
+        let value = Bytes::new();
+        let mut entry = Entry::new(key, &value);
+        entry.mark_tombstone();
         self.write(entry)?;
         Ok(())
     }
@@ -201,7 +210,7 @@ impl Transaction {
                 // Check if the key is in the write set by checking in the write_order_map map.
                 if let Some(order) = self.write_order_map.get(&hashed_key) {
                     if let Some(entry) = self.write_set.get(*order as usize) {
-                        return Ok(if entry.1.is_deleted() {
+                        return Ok(if entry.1.is_deleted_or_tombstone() {
                             None
                         } else {
                             Some(entry.1.value.clone().to_vec())
@@ -1817,5 +1826,41 @@ mod tests {
         assert!(val.is_none());
         let val = txn4.get(&key2).unwrap().unwrap();
         assert_eq!(val, value.as_ref());
+    }
+
+    #[tokio::test]
+    async fn test_insert_clear_read_key() {
+        let (store, _) = create_store(false);
+
+        // Key-value pair for the test
+        let key = Bytes::from("test_key");
+        let value1 = Bytes::from("test_value1");
+        let value2 = Bytes::from("test_value2");
+
+        // Insert key-value pair in a new transaction
+        {
+            let mut txn = store.begin().unwrap();
+            txn.set(&key, &value1).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        {
+            let mut txn = store.begin().unwrap();
+            txn.set(&key, &value2).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        // Clear the key in a separate transaction
+        {
+            let mut txn = store.begin().unwrap();
+            txn.clear(&key).unwrap(); // Assuming delete method clears the key
+            txn.commit().await.unwrap();
+        }
+
+        // Read the key in a new transaction to verify it does not exist
+        {
+            let txn = store.begin().unwrap();
+            assert!(txn.get(&key).unwrap().is_none());
+        }
     }
 }


### PR DESCRIPTION
## Description

Updates surrealkv version to 0.2.1, which includes the addition of the [`clear`](https://github.com/surrealdb/surrealkv/pull/47) method on a transaction