### PR TITLE
chore: add methods to get keys at specific timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.3.1"
-source = "git+https://github.com/surrealdb/vart?branch=chore/add-versioned-apis#306abfb09bf3e5d5b78125cf613d4b7580b8713a"
+source = "git+https://github.com/surrealdb/vart?branch=main#bf8002685f7d1e3e06c8307bb1e11898e6fbea66"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,8 +1486,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.3.1"
-source = "git+https://github.com/surrealdb/vart?branch=main#bf8002685f7d1e3e06c8307bb1e11898e6fbea66"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e19cf5555815b1ebc839ceb17face450eb0346e09c0acc6ad0e3097ec49dcad"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,8 +1487,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858e0a7c88fd62d483dd906e2ae63f8601939204cac227cb31dac6b530616ac8"
+source = "git+https://github.com/surrealdb/vart?branch=chore/add-versioned-apis#3695e0897988b6ca8d564db8ff295df61088f5b0"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.3.1"
-source = "git+https://github.com/surrealdb/vart?branch=chore/add-versioned-apis#3695e0897988b6ca8d564db8ff295df61088f5b0"
+source = "git+https://github.com/surrealdb/vart?branch=chore/add-versioned-apis#306abfb09bf3e5d5b78125cf613d4b7580b8713a"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = "0.3.1"
+vart = {git = "https://github.com/surrealdb/vart", branch = "chore/add-versioned-apis"}
 revision = "0.7.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = {git = "https://github.com/surrealdb/vart", branch = "chore/add-versioned-apis"}
+vart = {git = "https://github.com/surrealdb/vart", branch = "main"}
 revision = "0.7.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 sha2 = "0.10.8"
 quick_cache = "0.5.1"
-vart = {git = "https://github.com/surrealdb/vart", branch = "main"}
+vart = "0.4.0"
 revision = "0.7.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information on the underlying immutable versioned adaptive radix tries 
 - [x] **Embeddable**
 - [x] **ACID Semantics** 
 - [x] **Transaction Support:** 
-- [ ] **Built-in Item Versioning API**
+- [x] **Built-in Item Versioning API**
 - [x] **Multi-Version Concurrency Control (MVCC) support**
 - [x] **Multiple Concurrent Readers and Writers**
 - [x] **Persistence through an append-only File**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,4 @@ pub mod storage;
 pub use storage::kv::error::{Error, Result};
 pub use storage::kv::option::{IsolationLevel, Options};
 pub use storage::kv::store::Store;
-pub use storage::kv::transaction::{Durability, Transaction};
+pub use storage::kv::transaction::{Durability, Transaction, Mode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,4 @@ pub mod storage;
 pub use storage::kv::error::{Error, Result};
 pub use storage::kv::option::{IsolationLevel, Options};
 pub use storage::kv::store::Store;
-pub use storage::kv::transaction::{Durability, Transaction, Mode};
+pub use storage::kv::transaction::{Durability, Mode, Transaction};

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -98,8 +98,8 @@ impl StoreInner {
 
         // Start compaction process
         let snapshot_lock = self.core.indexer.write();
-        let mut snapshot = snapshot_lock.snapshot()?;
-        let snapshot_iter = snapshot.new_reader()?;
+        let snapshot = snapshot_lock.snapshot()?;
+        let snapshot_versioned_iter = snapshot.iter_with_versions()?;
         drop(snapshot_lock); // Explicitly drop the lock
         drop(oracle_lock); // Release the oracle lock
 
@@ -145,7 +145,7 @@ impl StoreInner {
         let mut entries_buffer = Vec::new();
         let mut skip_current_key = false;
 
-        for (key, value, version, ts) in snapshot_iter.iter_with_versions() {
+        for (key, value, version, ts) in snapshot_versioned_iter {
             let mut val_ref = ValueRef::new(self.core.clone());
             val_ref.decode(*version, value)?;
 

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -140,7 +140,6 @@ impl StoreInner {
             Ok(())
         };
 
-        // IMP! TODO! This is wrong because we are not storing each version of the key
         let mut current_key: Option<Vec<u8>> = None;
         let mut entries_buffer = Vec::new();
         let mut skip_current_key = false;

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -98,8 +98,8 @@ impl StoreInner {
 
         // Start compaction process
         let snapshot_lock = self.core.indexer.write();
-        let snapshot = snapshot_lock.snapshot()?;
-        let snapshot_versioned_iter = snapshot.iter_with_versions()?;
+        let snapshot = snapshot_lock.snapshot();
+        let snapshot_versioned_iter = snapshot.iter_with_versions();
         drop(snapshot_lock); // Explicitly drop the lock
         drop(oracle_lock); // Release the oracle lock
 

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -241,7 +241,7 @@ impl Record {
     }
 }
 
-pub(crate) trait Value {
+pub trait Value {
     fn resolve(&self) -> Result<Vec<u8>>;
     fn ts(&self) -> u64;
     fn metadata(&self) -> Option<&Metadata>;

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -47,6 +47,7 @@ pub enum Error {
     InvalidOperation,            // Invalid operation
     CompactionSegmentSizeTooSmall, // The segment size is too small for compaction
     SegmentIdExceedsLastUpdated, // The segment ID exceeds the last updated segment
+    TransactionMustBeReadOnly,   // The transaction must be read-only
 }
 
 /// Error structure for encoding errors
@@ -130,6 +131,9 @@ impl fmt::Display for Error {
             }
             Error::SegmentIdExceedsLastUpdated => {
                 write!(f, "Segment ID exceeds the last updated segment")
+            }
+            Error::TransactionMustBeReadOnly => {
+                write!(f, "Transaction must be read-only")
             }
         }
     }

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -67,10 +67,4 @@ impl Indexer {
     pub fn version(&self) -> u64 {
         self.index.version()
     }
-
-    /// Closes the index.
-    pub(crate) fn close(&mut self) -> Result<()> {
-        self.index.close()?;
-        Ok(())
-    }
 }

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -52,7 +52,7 @@ impl Indexer {
             self.index.insert(key, value.clone(), version, ts)?;
         } else {
             self.index
-                .insert_without_version_increment_check(key, value.clone(), version, ts)?;
+                .insert_unchecked(key, value.clone(), version, ts)?;
         }
         Ok(())
     }

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -16,16 +16,14 @@ pub(crate) struct Indexer {
 
 impl Indexer {
     /// Creates a new `Indexer` instance.
-    /// The maximum number of active snapshots is set based on the provided options.
     pub(crate) fn new() -> Self {
         let index = VartIndex::new();
         Self { index }
     }
 
     /// Creates a snapshot of the current state of the index.
-    pub(crate) fn snapshot(&self) -> Result<VartSnapshot<VariableSizeKey, Bytes>> {
-        let snapshot = self.index.create_snapshot()?;
-        Ok(snapshot)
+    pub(crate) fn snapshot(&self) -> VartSnapshot<VariableSizeKey, Bytes> {
+        self.index.create_snapshot()
     }
 
     /// Inserts multiple key-value pairs into the index.
@@ -57,10 +55,9 @@ impl Indexer {
         Ok(())
     }
 
-    pub fn delete(&mut self, key: &mut VariableSizeKey) -> Result<()> {
+    pub fn delete(&mut self, key: &mut VariableSizeKey) {
         *key = key.terminate();
-        self.index.remove(key)?;
-        Ok(())
+        self.index.remove(key);
     }
 
     /// Returns the current version of the index.

--- a/src/storage/kv/meta.rs
+++ b/src/storage/kv/meta.rs
@@ -54,7 +54,7 @@ impl Attribute {
 /// A structure representing metadata for a key-value pair.
 /// The metadata consists of a set of attributes.
 #[derive(Clone, Debug)]
-pub(crate) struct Metadata {
+pub struct Metadata {
     attributes: HashSet<Attribute>,
 }
 

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -13,7 +13,7 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use hashbrown::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::Mutex as AsyncMutex;
-use vart::{TrieError, VariableSizeKey};
+use vart::VariableSizeKey;
 
 use crate::storage::kv::{
     error::{Error, Result},
@@ -169,7 +169,7 @@ impl SnapshotIsolation {
                         return Err(Error::TransactionReadConflict);
                     }
                 }
-                Err(Error::IndexError(TrieError::KeyNotFound)) => {
+                Err(Error::KeyNotFound) => {
                     if *ts > 0 {
                         return Err(Error::TransactionReadConflict);
                     }

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -15,21 +15,21 @@ use vart::{
 pub(crate) const FILTERS: [fn(&ValueRef, u64) -> Result<()>; 1] = [ignore_deleted];
 
 /// A versioned snapshot for snapshot isolation.
-pub(crate) struct Snapshot {
+pub struct Snapshot {
     /// The timestamp of the snapshot. This is used to determine the visibility of the
     /// key-value pairs in the snapshot. It can be used to filter out expired key-value
     /// pairs or deleted key-value pairs based on the read timestamp.
-    ts: u64,
+    start_ts: u64,
     snap: TartSnapshot<VariableSizeKey, Bytes>,
     store: Arc<Core>,
 }
 
 impl Snapshot {
-    pub(crate) fn take(store: Arc<Core>, ts: u64) -> Result<Self> {
+    pub(crate) fn take(store: Arc<Core>, start_ts: u64) -> Result<Self> {
         let snapshot = store.indexer.write().snapshot()?;
 
         Ok(Self {
-            ts,
+            start_ts,
             snap: snapshot,
             store,
         })
@@ -41,7 +41,7 @@ impl Snapshot {
         // This happens because the VariableSizeKey transfrom from
         // a &[u8] does not terminate the key with a null byte.
         let key = &key.terminate();
-        self.snap.insert(key, value, self.snap.ts())?;
+        self.snap.insert(key, value, self.snap.version())?;
         Ok(())
     }
 
@@ -55,37 +55,56 @@ impl Snapshot {
         Ok(())
     }
 
-    /// Retrieves the value and timestamp associated with the given key from the snapshot.
-    pub fn get(&self, key: &VariableSizeKey) -> Result<Box<dyn Value>> {
-        // TODO: need to fix this to avoid cloning the key
-        // This happens because the VariableSizeKey transfrom from
-        // a &[u8] does not terminate the key with a null byte.
-        let key = &key.terminate();
-        self.get_with_filters(key, &FILTERS)
+    pub fn new_reader(&mut self) -> Result<IterationPointer<VariableSizeKey, Bytes>> {
+        Ok(self.snap.new_reader()?)
     }
 
-    pub fn get_with_filters<F>(
+    fn decode_and_apply_filters(
         &self,
-        key: &VariableSizeKey,
-        filters: &[F],
-    ) -> Result<Box<dyn Value>>
-    where
-        F: FilterFn,
-    {
-        let (val, version, _) = self.snap.get(key)?;
+        val_bytes: &Bytes,
+        version: u64,
+        filters: &[impl FilterFn],
+    ) -> Result<Box<dyn Value>> {
         let mut val_ref = ValueRef::new(self.store.clone());
-        let val_bytes_ref: &Bytes = &val;
-        val_ref.decode(version, val_bytes_ref)?;
+        val_ref.decode(version, val_bytes)?;
 
         for filter in filters {
-            filter.apply(&val_ref, self.ts)?
+            filter.apply(&val_ref, self.start_ts)?;
         }
 
         Ok(Box::new(val_ref))
     }
 
-    pub fn new_reader(&mut self) -> Result<IterationPointer<VariableSizeKey, Bytes>> {
-        Ok(self.snap.new_reader()?)
+    /// Retrieves the latest value associated with the given key from the snapshot.
+    pub fn get(&self, key: &VariableSizeKey) -> Result<Box<dyn Value>> {
+        // TODO: need to fix this to avoid cloning the key
+        // This happens because the VariableSizeKey transfrom from
+        // a &[u8] does not terminate the key with a null byte.
+        let key = &key.terminate();
+        let (val, version, _) = self.snap.get(key)?;
+        self.decode_and_apply_filters(&val, version, &FILTERS)
+    }
+
+    /// Retrieves the value associated with the given key at the given timestamp from the snapshot.
+    pub fn get_at_ts(&self, key: &VariableSizeKey, ts: u64) -> Result<Box<dyn Value>> {
+        let key = &key.terminate();
+        let (val, version) = self.snap.get_at_ts(key, ts)?;
+        self.decode_and_apply_filters(&val, version, &FILTERS)
+    }
+
+    /// Retrieves the version history of the value associated with the given key from the snapshot.
+    pub fn get_version_history(&self, key: &VariableSizeKey) -> Result<Vec<(Box<dyn Value>, u64)>> {
+        let key = &key.terminate();
+
+        let mut results = Vec::new();
+
+        let items = self.snap.get_version_history(key)?;
+        for (value, version, ts) in items {
+            let result = self.decode_and_apply_filters(&value, version, &FILTERS)?;
+            results.push((result, ts));
+        }
+
+        Ok(results)
     }
 }
 
@@ -109,5 +128,83 @@ where
 {
     fn apply(&self, val_ref: &ValueRef, ts: u64) -> Result<()> {
         self(val_ref, ts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::kv::option::Options;
+    use crate::storage::kv::store::Store;
+
+    use bytes::Bytes;
+    use tempdir::TempDir;
+
+    fn create_temp_directory() -> TempDir {
+        TempDir::new("test").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_versioned_key_value_updates() {
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
+
+        // Setup store options with the temporary directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
+
+        // Initialize the store with VariableKey as the key type
+        let store = Store::new(opts).expect("Failed to create store");
+
+        // Define key and its versioned values
+        let key = Bytes::from("testKey");
+        let initial_value = Bytes::from("initialValue");
+        let updated_value = Bytes::from("updatedValue");
+
+        // Helper function to reduce repetition
+        async fn set_value(store: &Store, key: &Bytes, value: &Bytes) {
+            let mut txn = store.begin().expect("Failed to begin transaction");
+            txn.set(key, value).expect("Failed to set value");
+            txn.commit().await.expect("Failed to commit transaction");
+        }
+
+        // Set initial value
+        set_value(&store, &key, &initial_value).await;
+
+        // Update value
+        set_value(&store, &key, &updated_value).await;
+
+        // Retrieve and verify the history
+        let history = store.get_history(&key).expect("Failed to get history");
+        assert_eq!(history.len(), 2, "History should contain two entries");
+        assert_eq!(
+            history[0].0, initial_value,
+            "First entry should match initial value"
+        );
+        assert_eq!(
+            history[1].0, updated_value,
+            "Second entry should match updated value"
+        );
+
+        // Verify timestamps are in increasing order
+        assert!(
+            history[0].1 < history[1].1,
+            "Timestamps should be in increasing order"
+        );
+
+        // Verify retrieval at specific timestamps
+        let initial_ts = history[0].1;
+        let updated_ts = history[1].1;
+        assert_eq!(
+            store
+                .get_at_ts(&key, initial_ts)
+                .expect("Failed to get value at initial timestamp"),
+            initial_value
+        );
+        assert_eq!(
+            store
+                .get_at_ts(&key, updated_ts)
+                .expect("Failed to get value at updated timestamp"),
+            updated_value
+        );
     }
 }

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -214,7 +214,8 @@ mod tests {
         let store = Store::new(opts).expect("Failed to create store");
 
         // Define multiple keys and their versioned values
-        let keys_values = [(
+        let keys_values = [
+            (
                 Bytes::from("k1"),
                 Bytes::from("value1"),
                 Bytes::from("value1Updated"),
@@ -223,7 +224,8 @@ mod tests {
                 Bytes::from("k2"),
                 Bytes::from("value2"),
                 Bytes::from("value2Updated"),
-            )];
+            ),
+        ];
 
         // Set and update values for all keys
         for (key, initial_value, updated_value) in keys_values.iter() {
@@ -294,7 +296,8 @@ mod tests {
         let store = Store::new(opts).expect("Failed to create store");
 
         // Define multiple keys and their versioned values
-        let keys_values = [(
+        let keys_values = [
+            (
                 Bytes::from("k1"),
                 Bytes::from("value1"),
                 Bytes::from("value1Updated"),
@@ -303,7 +306,8 @@ mod tests {
                 Bytes::from("k2"),
                 Bytes::from("value2"),
                 Bytes::from("value2Updated"),
-            )];
+            ),
+        ];
 
         // Set and update values for all keys
         for (key, initial_value, updated_value) in keys_values.iter() {

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -9,6 +9,7 @@ use crate::storage::{
 };
 
 use vart::{
+    art::QueryType,
     iter::{Iter, VersionedIter},
     snapshot::Snapshot as VartSnapshot,
     TrieError, VariableSizeKey,
@@ -135,6 +136,30 @@ impl Snapshot {
         R: RangeBounds<VariableSizeKey> + 'a,
     {
         self.snap.range_with_versions(range).map_err(|e| e.into())
+    }
+
+    pub fn get_value_by_query(
+        &self,
+        key: &VariableSizeKey,
+        query_type: QueryType,
+    ) -> Result<(Bytes, u64, u64)> {
+        self.snap
+            .get_value_by_query(key, query_type)
+            .map_err(|e| e.into())
+    }
+
+    pub fn scan_at_ts<R>(&self, range: R, ts: u64) -> Result<Vec<(Vec<u8>, Bytes)>>
+    where
+        R: RangeBounds<VariableSizeKey>,
+    {
+        self.snap.scan_at_ts(range, ts).map_err(|e| e.into())
+    }
+
+    pub fn keys_at_ts<R>(&self, range: R, ts: u64) -> Result<Vec<Vec<u8>>>
+    where
+        R: RangeBounds<VariableSizeKey>,
+    {
+        self.snap.keys_at_ts(range, ts).map_err(|e| e.into())
     }
 }
 

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -184,35 +184,6 @@ impl Store {
         Ok(())
     }
 
-    /// Returns the value associated with the key.
-    pub fn get(&self, key: &[u8]) -> Result<Vec<u8>> {
-        let core = self.inner.as_ref().unwrap().core.clone();
-        let snapshot = Snapshot::take(core, now())?;
-        let val_ref = snapshot.get(&key[..].into())?;
-        val_ref.resolve()
-    }
-
-    /// Returns the value associated with the key at the given timestamp.
-    pub fn get_at_ts(&self, key: &[u8], ts: u64) -> Result<Vec<u8>> {
-        let core = self.inner.as_ref().unwrap().core.clone();
-        let snapshot = Snapshot::take(core, now())?;
-        let val_ref = snapshot.get_at_ts(&key[..].into(), ts)?;
-        val_ref.resolve()
-    }
-
-    /// Returns all the versioned values and timestamps associated with the key.
-    pub fn get_history(&self, key: &[u8]) -> Result<Vec<(Vec<u8>, u64)>> {
-        let mut results = Vec::new();
-        let core = self.inner.as_ref().unwrap().core.clone();
-        let snapshot = Snapshot::take(core, now())?;
-        let values_ref = snapshot.get_version_history(&key[..].into())?;
-        for (value, ts) in values_ref {
-            let resolved_value = value.resolve()?;
-            results.push((resolved_value, ts));
-        }
-        Ok(results)
-    }
-
     /// Returns a point-in-time snapshot of the store.
     pub fn get_snapshot(&self) -> Result<Snapshot> {
         let core = self.inner.as_ref().unwrap().core.clone();

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -466,7 +466,7 @@ impl Core {
             .as_ref()
             .map_or(false, |metadata| metadata.is_deleted())
         {
-            indexer.delete(&mut entry.key[..].into())?;
+            indexer.delete(&mut entry.key[..].into());
         } else {
             let (segment_id, val_off) = value_offsets.get(&entry.key).unwrap();
 
@@ -699,7 +699,7 @@ impl Core {
             // If the entry is marked as deleted, delete it.
             if let Some(metadata) = entry.metadata.as_ref() {
                 if metadata.is_deleted() {
-                    index.delete(&mut entry.key[..].into())?;
+                    index.delete(&mut entry.key[..].into());
                     continue;
                 }
             }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -628,9 +628,6 @@ impl Core {
         let last_commit_ts = oracle.read_ts();
         oracle.wait_for(last_commit_ts);
 
-        // Close the indexer
-        self.indexer.write().close()?;
-
         // Close the commit log if it exists
         if let Some(clog) = &self.clog {
             clog.write().close()?;

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -345,15 +345,13 @@ impl Transaction {
         // Initialize an empty vector to store the results.
         let mut results = Vec::new();
 
-        // Create a new reader for the snapshot.
-        let iterator = match self.snapshot.as_ref().unwrap().write().new_reader() {
+        // Get a range iterator for the specified range.
+        let snap = self.snapshot.as_ref().unwrap().read();
+        let ranger = match snap.range(range) {
             Ok(reader) => reader,
             Err(Error::IndexError(TrieError::SnapshotEmpty)) => return Ok(Vec::new()),
             Err(e) => return Err(e),
         };
-
-        // Get a range iterator for the specified range.
-        let ranger = iterator.range(range);
 
         // Iterate over the keys in the range.
         'outer: for (key, value, version, ts) in ranger {

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -538,7 +538,7 @@ impl Transaction {
     }
 
     /// Returns key-value pairs within the specified range, at the given timestamp.
-    pub fn scan_at_ts<'b, R>(&'b self, range: R) -> Result<Vec<(Vec<u8>, Bytes)>>
+    pub fn scan_at_ts<'b, R>(&'b self, range: R, ts: u64) -> Result<Vec<(Vec<u8>, Bytes)>>
     where
         R: RangeBounds<&'b [u8]>,
     {
@@ -551,13 +551,13 @@ impl Transaction {
             .as_ref()
             .unwrap()
             .read()
-            .scan_at_ts(range, self.read_ts)?;
+            .scan_at_ts(range, ts)?;
 
         Ok(result)
     }
 
     /// Returns keys within the specified range, at the given timestamp.
-    pub fn keys_at_ts<'b, R>(&'b self, range: R) -> Result<Vec<Vec<u8>>>
+    pub fn keys_at_ts<'b, R>(&'b self, range: R, ts: u64) -> Result<Vec<Vec<u8>>>
     where
         R: RangeBounds<&'b [u8]>,
     {
@@ -570,7 +570,7 @@ impl Transaction {
             .as_ref()
             .unwrap()
             .read()
-            .keys_at_ts(range, self.read_ts)?;
+            .keys_at_ts(range, ts)?;
 
         Ok(result)
     }


### PR DESCRIPTION
## Description

This PR does the following:

1) Updates vart
2) Adds the following versioned APIs to the snapshot and tree
    - `get_at_ts` (to get a key at a particular timestamp)
    - `get_all_versions` (to get all the versions of a key)
    - `scan_at_ts` (scans all keys at a timestamp)
    - `keys_at_ts` (query all keys at a timestamp)
3) Add `get_value_by_query` to both tree and snapshot to query the value by the following query types
    - `LatestByVersion`
    - `LatestByTs`
    - `LastLessThanTs`
    - `LastLessOrEqualTs`
    - `FirstGreaterThanTs`
    - `FirstGreaterOrEqualTs`
