### PR TITLE
Fix panic in store_bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,26 +725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +738,16 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -821,6 +811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1366,10 +1365,10 @@ dependencies = [
  "fmmap",
  "futures",
  "hashbrown",
- "jemallocator",
  "libc",
  "lru",
  "memmap2",
+ "mimalloc",
  "nanoid",
  "parking_lot",
  "quick_cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1", features = ["full"] }
 tempdir = "0.3"
 rand = "0.8.5"
 criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
-jemallocator = "0.5.4"
+mimalloc = { version = "0.1.39", default-features = false }
 nanoid = "0.4.0"
 fastrand = "2.0.1"
 libc = "0.2.155"


### PR DESCRIPTION
Fix panic in `store_bench`:
```
$ RUST_BACKTRACE=1 cargo bench --bench store_bench
   Compiling surrealkv v0.3.0 (/Users/sergii/p/surrealkv)
    Finished `bench` profile [optimized] target(s) in 1.18s
     Running benches/store_bench.rs (target/release/deps/store_bench-edb8cc5dfa51a46c)
Gnuplot not found, using plotters backend
bulk load key/value lengths 10/0
                        time:   [15.518 µs 15.674 µs 15.863 µs]
                        change: [-3.1581% -1.7065% -0.3082%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high severe

thread 'main' panicked at src/storage/kv/store.rs:199:13:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_display
   3: tokio::task::spawn::spawn_inner::panic_cold_display
   4: tokio::task::spawn::spawn
   5: <surrealkv::storage::kv::store::Store as core::ops::drop::Drop>::drop
   6: store_bench::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: bench failed, to rerun pass `--bench store_bench`
```

Also, switch `store_bench` to `mimalloc` in order to be in sync with `surrealdb`.