### PR TITLE
Reduce allocations and lookups in the write path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
 name = "surrealkv"
 version = "0.3.0"
 dependencies = [
+ "ahash",
  "async-channel",
  "bytes",
  "chrono",
@@ -1325,7 +1326,6 @@ dependencies = [
  "fastrand",
  "fmmap",
  "futures",
- "hashbrown",
  "libc",
  "lru",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ rust-version = "1.74"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ahash = "0.8.11"
 crc32fast = "1.3.2"
 chrono = "0.4.31"
 parking_lot = "0.12.1"
-hashbrown = "0.14.2"
 lru = "0.12.0"
 async-channel = "2.1.1"
 futures = "0.3.30"

--- a/benches/collection_bench.rs
+++ b/benches/collection_bench.rs
@@ -1,5 +1,5 @@
+use ahash::{HashSet, HashSetExt};
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
-use hashbrown::HashSet;
 use rand::{thread_rng, Rng};
 use std::collections::VecDeque;
 

--- a/src/storage/cache/s3fifo.rs
+++ b/src/storage/cache/s3fifo.rs
@@ -1,7 +1,7 @@
 /// This is an experimental implementation of a cache that uses the S3-FIFO algorithm. This is not yet
 /// used in the main codebase. But the implementation is kept here for future reference for replacing it
 /// with the current LRU cache for caching recently accessed values.
-use hashbrown::HashMap;
+use ahash::{HashMap, HashMapExt};
 use std::cmp::min;
 use std::collections::LinkedList;
 use std::fmt::Debug;

--- a/src/storage/kv/meta.rs
+++ b/src/storage/kv/meta.rs
@@ -1,5 +1,5 @@
+use ahash::{HashSet, HashSetExt};
 use bytes::{BufMut, Bytes, BytesMut};
-use hashbrown::HashSet;
 
 use crate::storage::kv::error::{Error, Result};
 

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -8,9 +8,9 @@ use std::{
     },
 };
 
+use ahash::{HashMap, HashMapExt, HashSet};
 use async_channel::{bounded, Receiver, Sender};
 use bytes::Bytes;
-use hashbrown::{HashMap, HashSet};
 use parking_lot::{Mutex, RwLock};
 use tokio::sync::Mutex as AsyncMutex;
 use vart::VariableSizeKey;
@@ -363,8 +363,7 @@ impl SerializableSnapshotIsolation {
         assert!(ts >= commit_tracker.last_cleanup_ts);
 
         // Add the transaction to the list of committed transactions with conflict keys.
-        let conflict_keys: HashSet<Bytes> =
-            txn.write_set.iter().map(|(key, _)| key.clone()).collect();
+        let conflict_keys: HashSet<Bytes> = txn.write_set.iter().map(|e| e.key.clone()).collect();
 
         commit_tracker
             .committed_transactions

--- a/src/storage/kv/reader.rs
+++ b/src/storage/kv/reader.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 
 use bytes::BytesMut;
 
-use hashbrown::HashMap;
+use ahash::{HashMap, HashMapExt};
 
 use crate::storage::{
     kv::{

--- a/src/storage/log/mod.rs
+++ b/src/storage/log/mod.rs
@@ -9,8 +9,8 @@ use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::PoisonError;
 
+use ahash::{HashMap, HashMapExt};
 use crc32fast::Hasher;
-use hashbrown::HashMap;
 
 /// The size of a single block in bytes.
 ///


### PR DESCRIPTION
- Make transaction's `write_set` a vector of entries instead of a vector of tuples, since entry already contains key.
- On commit, extract the `write_set` with `mem::take()` instead of cloning.
- Use `HashMap::entry()` instead of a sequence of `get/insert` when checking if the key already exists in `write_order_map`.
- Remove the `Records` struct which was merely an intermediate vector of `Record`s for the encoding of entries.
- Replace `hashbrown` with `ahash`.