### PR TITLE
Remove block buffering from the write path

### DIFF
--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -145,7 +145,7 @@ fn repair_segment(
     std::fs::rename(&corrupted_segment_file_path, &repaired_segment_path)?;
 
     // Open a new segment as the active segment
-    let mut new_segment: Segment<0> = Segment::open(&aol.dir, corrupted_segment_id, &aol.opts)?;
+    let mut new_segment = Segment::open(&aol.dir, corrupted_segment_id, &aol.opts)?;
 
     // Create a segment reader for the repaired segment
     let segments: Vec<SegmentRef> = vec![SegmentRef {

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -64,12 +64,6 @@ pub type ScanResult = (Vec<u8>, Vec<u8>, u64, u64);
 
 #[derive(Default, Debug, Copy, Clone)]
 pub enum Durability {
-    /// Commits with this durability level will be queued for persitance to disk, and will be
-    /// written to disk in batches of BLOCK_SIZE. This helps reduce the number of disk writes,
-    /// and increases throughput as the data is written to disk in batches. But it does not
-    /// guarantee that the data will be persisted to disk as soon as [Transaction::commit] returns.
-    Weak,
-
     /// Commits with this durability level are guaranteed to be persistent eventually. The data
     /// is written to the disk, but it is not fsynced before returning from [Transaction::commit].
     #[default]


### PR DESCRIPTION
The `Weak` durability level is not really useful for our use case and can be removed. With it gone, there's no need in buffering writes either, since each record must be fully written into the segment's file descriptor and flushed to the OS buffers. This makes the write path simpler, and also reduces memory usage and copying.

What this PR does:
- Removes `Weak` durability level.
- Removes `Block` struct.
- Removes `flush()` methods because each record is flushed to the OS buffers by default.
- Uses `FileExt::read_at()` where available instead of seeking to and then reading the record.

Tested locally with surrealdb using `cargo make ci-api-integration-surrealkv`.

The block buffering is still used when loading the segments; this will be addressed in a follow-up PR.