### PR TITLE
Remove extra read buffering

### DIFF
--- a/src/storage/kv/manifest.rs
+++ b/src/storage/kv/manifest.rs
@@ -2,9 +2,7 @@ use revision::{revisioned, Revisioned};
 use std::path::Path;
 
 use super::reader::Reader;
-use crate::storage::log::{
-    write_field, Error as LogError, MultiSegmentReader, SegmentRef, BLOCK_SIZE,
-};
+use crate::storage::log::{write_field, Error as LogError, MultiSegmentReader, SegmentRef};
 use crate::{Error, Options, Result};
 
 #[revisioned(revision = 1)]
@@ -91,14 +89,14 @@ impl Manifest {
 
         let sr = SegmentRef::read_segments_from_directory(path)?;
         let reader = MultiSegmentReader::new(sr)?;
-        let mut reader = Reader::new_from(reader, BLOCK_SIZE);
+        let mut reader = Reader::new_from(reader);
 
         loop {
             // Read the next transaction record from the log.
             let mut len_buf = [0; 4];
             let res = reader.read(&mut len_buf); // Read 4 bytes for the length
             if let Err(e) = res {
-                if let Error::LogError(LogError::Eof(_)) = e {
+                if let Error::LogError(LogError::Eof) = e {
                     break;
                 } else {
                     return Err(e);

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -9,7 +9,7 @@ use crate::storage::{
         reader::{Reader, RecordReader},
         util::sanitize_directory,
     },
-    log::{Aol, Error as LogError, MultiSegmentReader, Segment, SegmentRef, BLOCK_SIZE},
+    log::{Aol, Error as LogError, MultiSegmentReader, Segment, SegmentRef},
 };
 
 /// The last active segment being written to in the append-only log (AOL) is usually the WAL in database terminology.
@@ -156,7 +156,7 @@ fn repair_segment(
     let segment_reader = MultiSegmentReader::new(segments)?;
 
     // Initialize a reader for the segment
-    let reader = Reader::new_from(segment_reader, BLOCK_SIZE);
+    let reader = Reader::new_from(segment_reader);
     let mut reader = RecordReader::new(reader, db_opts.max_key_size, db_opts.max_value_size);
 
     let mut count = 0;
@@ -349,7 +349,7 @@ mod tests {
 
     #[allow(unused)]
     fn find_corrupted_segment(sr: Vec<SegmentRef>, opts: Options) -> (u64, u64) {
-        let reader = Reader::new_from(MultiSegmentReader::new(sr).expect("should create"), 1000);
+        let reader = Reader::new_from(MultiSegmentReader::new(sr).expect("should create"));
         let mut tx_reader = RecordReader::new(reader, opts.max_key_size, opts.max_value_size);
         let mut tx = Record::new();
 

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -35,9 +35,7 @@ use crate::storage::{
         transaction::{Durability, Mode, Transaction},
         util::now,
     },
-    log::{
-        Aol, Error as LogError, MultiSegmentReader, Options as LogOptions, SegmentRef, BLOCK_SIZE,
-    },
+    log::{Aol, Error as LogError, MultiSegmentReader, Options as LogOptions, SegmentRef},
 };
 
 pub(crate) struct StoreInner {
@@ -399,7 +397,7 @@ impl Core {
         let reader = MultiSegmentReader::new(sr)?;
 
         // A Reader is created from the MultiSegmentReader with the maximum segment size and block size.
-        let reader = Reader::new_from(reader, BLOCK_SIZE);
+        let reader = Reader::new_from(reader);
 
         // A RecordReader is created from the Reader to read transactions.
         let mut tx_reader = RecordReader::new(reader, opts.max_key_size, opts.max_value_size);
@@ -425,7 +423,7 @@ impl Core {
                 }
 
                 // If the end of the file is reached, the loop is broken.
-                Err(Error::LogError(LogError::Eof(_))) => break,
+                Err(Error::LogError(LogError::Eof)) => break,
 
                 // If a corruption error is encountered, the segment ID and offset are stored and the loop is broken.
                 Err(Error::LogError(LogError::Corruption(err))) => {
@@ -558,7 +556,7 @@ impl Core {
         let sr = SegmentRef::read_segments_from_directory(manifest_subdir.as_path())
             .expect("should read segments");
         let reader = MultiSegmentReader::new(sr)?;
-        let mut reader = Reader::new_from(reader, BLOCK_SIZE);
+        let mut reader = Reader::new_from(reader);
 
         let mut manifests = Manifest::new(); // Initialize with an empty Vec
 
@@ -567,7 +565,7 @@ impl Core {
             let mut len_buf = [0; 4];
             let res = reader.read(&mut len_buf); // Read 4 bytes for the length
             if let Err(e) = res {
-                if let Error::LogError(LogError::Eof(_)) = e {
+                if let Error::LogError(LogError::Eof) = e {
                     break;
                 } else {
                     return Err(e);

--- a/src/storage/log/aol.rs
+++ b/src/storage/log/aol.rs
@@ -197,8 +197,8 @@ impl Aol {
                 r += bytes_read;
             }
             Err(e) => match e {
-                Error::Eof(n) => {
-                    return Err(Error::Eof(n));
+                Error::Eof => {
+                    return Err(Error::Eof);
                 }
                 _ => return Err(e),
             },


### PR DESCRIPTION
`MultiSegmentReader` already uses `BufReader` for buffering file reads in memory, therefore there's no need for `Reader` to also buffer reads manually with `Vec<u8>`, and all of the associated code and copying.

Tested locally with surrealdb using `cargo make ci-api-integration-surrealkv`.