### PR TITLE
Make get_at_ts available in read-write transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -468,8 +468,6 @@ impl Transaction {
 
     /// Returns the value associated with the key at the given timestamp.
     pub fn get_at_ts(&self, key: &[u8], ts: u64) -> Result<Vec<u8>> {
-        self.ensure_read_only_transaction()?;
-
         // If the key is empty, return an error.
         if key.is_empty() {
             return Err(Error::EmptyKey);


### PR DESCRIPTION
This change is needed for versioned queries.