### PR TITLE
Implement set_at_ts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -68,12 +68,11 @@ impl Entry {
 pub(crate) fn encode_entries(
     entries: &[Entry],
     tx_id: u64,
-    commit_ts: u64,
     buf: &mut BytesMut,
     offset_tracker: &mut HashMap<Bytes, u64>,
 ) {
     for entry in entries {
-        let tx_record_entry = Record::new_from_entry(entry.clone(), tx_id, commit_ts);
+        let tx_record_entry = Record::new_from_entry(entry.clone(), tx_id);
         let offset = tx_record_entry.encode(buf).unwrap();
         offset_tracker.insert(entry.key.clone(), offset as u64);
     }
@@ -150,10 +149,10 @@ impl Record {
         hasher.finalize()
     }
 
-    pub(crate) fn new_from_entry(entry: Entry, tx_id: u64, commit_ts: u64) -> Self {
+    pub(crate) fn new_from_entry(entry: Entry, tx_id: u64) -> Self {
         let rec = Record {
             id: tx_id,
-            ts: commit_ts,
+            ts: entry.ts,
             crc32: 0, // Temporarily set to 0, will be updated after initialization
             version: RECORD_VERSION,
             key_len: entry.key.len() as u32,

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -281,12 +281,12 @@ mod tests {
             assert_eq!(
                 txn.get_at_ts(key, initial_ts)
                     .expect("Failed to get value at initial timestamp"),
-                *initial_value
+                Some(initial_value.to_vec())
             );
             assert_eq!(
                 txn.get_at_ts(key, updated_ts)
                     .expect("Failed to get value at updated timestamp"),
-                *updated_value
+                Some(updated_value.to_vec())
             );
         }
     }


### PR DESCRIPTION
By default SKV sets the records' timestamp locally at commit time. Make it possible to override the timestamp using `set_at_ts`. This change is needed for CREATE with VERSION in SurrealDB.

- Implement `set_at_ts()`.
- Remove `commit_ts` and do not pass it around.
- Fix the signature of `get_at_ts()`.
- Bump the version.