### PR TITLE
Implement savepoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -48,6 +48,7 @@ pub enum Error {
     CompactionSegmentSizeTooSmall, // The segment size is too small for compaction
     SegmentIdExceedsLastUpdated, // The segment ID exceeds the last updated segment
     TransactionMustBeReadOnly,   // The transaction must be read-only
+    TransactionWithoutSavepoint, // The transaction does not have a savepoint set
 }
 
 // Implementation of Display trait for Error
@@ -108,6 +109,9 @@ impl fmt::Display for Error {
             }
             Error::TransactionMustBeReadOnly => {
                 write!(f, "Transaction must be read-only")
+            }
+            Error::TransactionWithoutSavepoint => {
+                write!(f, "Transaction does not have a savepoint set")
             }
         }
     }


### PR DESCRIPTION
- The API is modelled after RocksDB. `set_savepoint` is used to specify the state of a transaction to rollback to. `rollback_to_savepoint` is used to rollback to the latest savepoint.
- The savepoints are stackable. It's possible to set multiple savepoints within the same transaction and then rollback to each of them with the corresponding number of calls to `rollback_to_savepoint`.
- The implementation is quite simple. Each transaction stores the number of savepoints as `u32` with zero meaning none. When an entry is added to the transaction's write set, read set and scan set, its savepoint number is set to the current number of the transaction. In other words the entries are marked with the number of current savepoint. A call to `rollback_to_savepoint` merely removes all entries in the write set whose sevapoint number is equal to the transaction's one, and then it decrements it, stopping at 0.
- Bump the version.
- The draft SurrealDB PR is https://github.com/surrealdb/surrealdb/pull/4749.