### PR TITLE
Savepoint rollback on an updated key should roll it back to previous version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,15 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,20 +325,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "darling"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -364,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -378,23 +350,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.47",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -581,16 +543,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1240,17 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,7 +1276,6 @@ dependencies = [
  "quick_cache",
  "rand 0.8.5",
  "revision",
- "sha2",
  "tempdir",
  "tokio",
  "vart",
@@ -1374,18 +1314,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1431,12 +1371,6 @@ dependencies = [
  "quote",
  "syn 2.0.47",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async-channel = "2.1.1"
 futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
-sha2 = "0.10.8"
 quick_cache = "0.6.0"
 vart = "0.4.0"
 revision = "0.7.1"

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -367,7 +367,11 @@ impl SerializableSnapshotIsolation {
         assert!(ts >= commit_tracker.last_cleanup_ts);
 
         // Add the transaction to the list of committed transactions with conflict keys.
-        let conflict_keys: HashSet<Bytes> = txn.write_set.iter().map(|e| e.e.key.clone()).collect();
+        let conflict_keys: HashSet<Bytes> = txn
+            .write_set
+            .values()
+            .filter_map(|entries| entries.last().map(|entry| entry.e.key.clone()))
+            .collect();
 
         commit_tracker
             .committed_transactions

--- a/src/storage/kv/util.rs
+++ b/src/storage/kv/util.rs
@@ -4,23 +4,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bytes::Bytes;
 use chrono::Utc;
-use crc32fast::Hasher as crc32Hasher;
-use sha2::{Digest, Sha256};
 use vart::VariableSizeKey;
 
 use crate::Result;
-
-/// Calculates the CRC32 hash of a byte array.
-/// It creates a new CRC32 hasher, updates it with the byte array, and finalizes the hash.
-/// It returns the hash as a 32-bit unsigned integer.
-#[allow(unused)]
-pub(crate) fn calculate_crc32(buf: &[u8]) -> u32 {
-    let mut hasher = crc32Hasher::new();
-    hasher.update(buf);
-    hasher.finalize()
-}
 
 /// Gets the current time in nanoseconds since the Unix epoch.
 /// It gets the current time in UTC, extracts the timestamp in nanoseconds, and asserts that the timestamp is positive.
@@ -30,13 +17,6 @@ pub(crate) fn now() -> u64 {
     let timestamp = utc_now.timestamp_nanos_opt().unwrap();
     assert!(timestamp > 0);
     timestamp as u64
-}
-
-pub(crate) fn sha256(arg: Bytes) -> Bytes {
-    let mut hasher = Sha256::new();
-    hasher.update(arg);
-    let result = hasher.finalize();
-    Bytes::copy_from_slice(result.as_slice())
 }
 
 pub(crate) fn sanitize_directory(directory: &str) -> std::io::Result<PathBuf> {


### PR DESCRIPTION
Fixes https://github.com/surrealdb/surrealkv/issues/76.

- Make `write_set` a map from keys to a vec of value versions, each for a different savepoint. That way we could keep the values across savepoints and properly rollback to a previous version by re-adding it to the snapshot.
- ~~Making `write_set` a map also allowed me to get rid of `write_order_map` which has not been used anyway, meaning that we do not care about the order.~~ With it, we can also get rid of the expensive `sha256` calculations for keys, and also remove `sha2` as a dependency.
(Update) The order of writes within a transaction is now preserved with per-transaction sequence numbers.
- In `Transaction::get`, the write set is now checked first, before attempting the snapshot.
- Clean up `Transaction` by removing unused `buf` and `committed_values_offsets` fields.