### PR TITLE
remove tokio sync primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,10 +79,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 4.0.3",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-semaphore"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538c756e85eb6ffdefaec153804afb6da84b033e2e5ec3e9d459c34b4bf4d3f6"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -395,6 +413,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -410,7 +434,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -1256,10 +1280,12 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "async-channel",
+ "async-mutex",
+ "async-semaphore",
  "bytes",
  "chrono",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
 vart = "0.4.0"
 revision = "0.7.1"
+async-semaphore = "1.2.0"
+async-mutex = "1.4.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -68,7 +68,7 @@ impl StoreInner {
 
         // Lock the oracle to prevent operations during compaction
         let oracle = self.core.oracle.clone();
-        let oracle_lock = oracle.write_lock.lock().await;
+        let oracle_lock = oracle.write_barrier.acquire().await;
 
         // Rotate the commit log and get the new segment ID
         let mut clog = self.core.clog.as_ref().unwrap().write();

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -5,11 +5,9 @@ use std::sync::Arc;
 use std::vec;
 
 use async_channel::{bounded, Receiver, Sender};
+use async_mutex::Mutex as AsyncMutex;
 use futures::{select, FutureExt};
-use tokio::{
-    sync::Mutex as AsyncMutex,
-    task::{spawn, JoinHandle},
-};
+use tokio::task::{spawn, JoinHandle};
 
 use ahash::{HashMap, HashMapExt};
 use bytes::{Bytes, BytesMut};

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -461,7 +461,7 @@ impl Transaction {
 
         // Lock the oracle to serialize commits to the transaction log.
         let oracle = self.core.oracle.clone();
-        let write_ch_lock = oracle.write_lock.lock().await;
+        let write_ch_lock = oracle.write_barrier.acquire().await;
 
         // Prepare for the commit by getting a transaction ID.
         let tx_id = self.prepare_commit()?;


### PR DESCRIPTION
As per https://github.com/surrealdb/surrealkv/issues/80, this PR will attempt to remove Tokio related sync primitives with `async_mutex` and `async_semaphore`. 

Technically speaking, the behavior shouldn't be that much differed, the few things that needs to be taken noticed on is only in fairness guarantee, whether one mutex lock would starve another, and whether or not two mutex lock re-entrancy would cause a live-lock or not.

As for `async_semaphore`, I noticed how the "write lock" for the oracle doesn't need a lock at all; it just need a critical section to prevent concurrent access. While I couldn't find any async critical section crate, I think replacing it with a semaphore would better indicate its functionality, hence the change.