### PR TITLE
Remove Tokio requirement and move into a user supplied spawner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "async-channel",

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -1,18 +1,23 @@
-use std::{fmt::Display, future::Future};
+use std::{
+    fmt::{Display, Formatter},
+    future::Future,
+    pin::Pin,
+    result::Result,
+};
 
 #[derive(Debug)]
 pub struct JoinError;
 
 impl Display for JoinError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str("JoinError")
     }
 }
 
-pub trait JoinHandle<T>: Future<Output = std::result::Result<T, JoinError>> + Send {}
+pub trait JoinHandle<T>: Future<Output = Result<T, JoinError>> + Send {}
 
 pub trait TaskSpawner: Send + Sync + 'static {
-    fn spawn<F>(f: F) -> impl JoinHandle<F::Output>
+    fn spawn<F>(f: F) -> Pin<Box<dyn JoinHandle<F::Output>>>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;

--- a/src/async_runtime.rs
+++ b/src/async_runtime.rs
@@ -1,0 +1,21 @@
+use std::{fmt::Display, future::Future};
+
+#[derive(Debug)]
+pub struct JoinError;
+
+impl Display for JoinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("JoinError")
+    }
+}
+
+pub trait JoinHandle<T>: Future<Output = std::result::Result<T, JoinError>> + Send {}
+
+pub trait TaskSpawner: Send + Sync + 'static {
+    fn spawn<F>(f: F) -> impl JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+}
+
+pub mod tokio;

--- a/src/async_runtime/tokio.rs
+++ b/src/async_runtime/tokio.rs
@@ -10,12 +10,12 @@ use super::{JoinError, JoinHandle, TaskSpawner};
 pub struct TokioSpawner;
 
 impl TaskSpawner for TokioSpawner {
-    fn spawn<F>(f: F) -> impl JoinHandle<F::Output>
+    fn spawn<F>(f: F) -> Pin<Box<dyn JoinHandle<F::Output>>>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        TokioJoinHandle(tokio::spawn(f))
+        Box::pin(TokioJoinHandle(tokio::spawn(f)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ pub use storage::kv::error::{Error, Result};
 pub use storage::kv::option::{IsolationLevel, Options};
 pub use storage::kv::store::Store;
 pub use storage::kv::transaction::{Durability, Mode, Transaction};
+
+pub mod async_runtime;

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -68,7 +68,7 @@ impl<T: TaskSpawner> StoreInner<T> {
             stop_tx,
             is_closed: AtomicBool::new(false),
             is_compacting: AtomicBool::new(false),
-            task_runner_handle: Arc::new(AsyncMutex::new(Some(Box::pin(task_runner_handle)))),
+            task_runner_handle: Arc::new(AsyncMutex::new(Some(task_runner_handle))),
             stats: Arc::new(StorageStats::new()),
             _phantom: PhantomData,
         })
@@ -226,7 +226,7 @@ impl<T: TaskSpawner> TaskRunnerImpl<T> {
         }
     }
 
-    fn spawn(self) -> impl JoinHandle<()> {
+    fn spawn(self) -> Pin<Box<dyn JoinHandle<()>>> {
         T::spawn(async move {
             loop {
                 select! {


### PR DESCRIPTION
This PR is part of #80 to remove Tokio from the library crate itself. The test and everything else (including the API usage) should still work the same. 

However, this is still a major interface change (added a new trait bound) so a semver change is also required.