### PR TITLE
Read set and key ranges do not need mutex

### DIFF
--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -103,7 +103,7 @@ fn sequential_insert_read(c: &mut Criterion) {
 
                 let current_count = count.load(Relaxed);
                 if current_count <= max_count.load(Relaxed) {
-                    let txn = db.begin().unwrap();
+                    let mut txn = db.begin().unwrap();
                     txn.get(&current_count.to_be_bytes()[..]).unwrap();
                 }
             })

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -512,7 +512,7 @@ mod tests {
         // Read the keys to the store
         for key in keys.iter().skip(num_keys_to_delete) {
             // Start a new read transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn matches default_value
             assert_eq!(val, default_value.as_ref());
@@ -572,7 +572,7 @@ mod tests {
 
         // Verify that deleted keys are not present
         for key in keys.iter().take(num_keys_to_delete) {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             assert!(txn.get(key).unwrap().is_none());
         }
 
@@ -582,14 +582,14 @@ mod tests {
             .skip(num_keys_to_delete)
             .take(num_keys_to_write / 2 - num_keys_to_delete)
         {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, updated_value.as_ref());
         }
 
         // Verify that the second half of the keys still have the default value
         for key in keys.iter().skip(num_keys_to_write / 2) {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -633,7 +633,7 @@ mod tests {
 
         // Verify that all keys still exist with the correct value
         for key in keys.iter() {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -695,14 +695,14 @@ mod tests {
 
         // Verify initial keys are present
         for key in initial_keys.iter() {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
 
         // Verify post-compaction keys are present
         for key in post_compaction_keys.iter() {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -791,7 +791,7 @@ mod tests {
         // Verify initial keys are present (except deleted ones)
         for key in &initial_keys {
             if !keys_to_delete.contains(key) {
-                let txn = reopened_store.begin().unwrap();
+                let mut txn = reopened_store.begin().unwrap();
                 let val = txn.get(key).unwrap().unwrap();
                 assert_eq!(val, default_value.as_ref());
             }
@@ -799,13 +799,13 @@ mod tests {
 
         // Verify deleted keys are not present
         for key in &keys_to_delete {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             assert!(txn.get(key).unwrap().is_none());
         }
 
         // Verify post-compaction keys are present
         for key in &post_compaction_keys {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -868,7 +868,7 @@ mod tests {
 
         // Verify initial keys have default value or overlapping value
         for key in &keys {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             if overlapping_keys.contains(key) {
                 assert_eq!(val, overlapping_value.as_ref());
@@ -936,7 +936,7 @@ mod tests {
         let reopened_store = Store::new(opts).expect("Failed to reopen store");
 
         for key in &keys {
-            let txn = reopened_store
+            let mut txn = reopened_store
                 .begin()
                 .expect("Failed to begin transaction on reopened store");
             assert!(
@@ -1003,7 +1003,7 @@ mod tests {
 
         // Verify the first half of the keys are deleted and the second half still exist
         for (i, key) in keys.iter().enumerate() {
-            let txn = reopened_store
+            let mut txn = reopened_store
                 .begin()
                 .expect("Failed to begin transaction on reopened store");
             let result = txn.get(key).expect("Failed to get key");
@@ -1079,7 +1079,7 @@ mod tests {
 
         // Randomly read keys to verify their integrity
         for (key, expected_value) in &keys_and_values {
-            let txn = reopened_store
+            let mut txn = reopened_store
                 .begin()
                 .expect("Failed to begin transaction on reopened store");
             if let Some(value) = txn.get(key).expect("Failed to get key") {
@@ -1123,7 +1123,7 @@ mod tests {
                 let key = format!("key{}", j);
                 let value = format!("value{}", j);
                 let value = value.into_bytes();
-                let txn = store.begin().unwrap();
+                let mut txn = store.begin().unwrap();
                 let val = txn.get(key.as_bytes()).unwrap().unwrap();
 
                 assert_eq!(val, value);
@@ -1179,7 +1179,7 @@ mod tests {
         let store = Store::new(opts).expect("should reopen store");
 
         // Begin a new transaction to verify compaction results
-        let txn = store.begin().unwrap();
+        let mut txn = store.begin().unwrap();
 
         // Check that "key1" is not present because its last version was marked as deleted
         assert!(
@@ -1237,7 +1237,7 @@ mod tests {
         let store = Store::new(opts).expect("should reopen store");
 
         // Begin a new transaction to verify compaction results
-        let txn = store.begin().unwrap();
+        let mut txn = store.begin().unwrap();
 
         // Check that "key1" is present and its value is the last inserted value
         let val = txn
@@ -1298,7 +1298,7 @@ mod tests {
 
         // Verify the results
         for key_index in 1..=num_keys {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let key = format!("key{}", key_index).as_bytes().to_vec();
             let expected_value = if key_index > multiple_versions_threshold {
                 format!("value{}_2", key_index)
@@ -1374,7 +1374,7 @@ mod tests {
 
         // Verify the results
         for key_index in 1..=num_keys {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let key = format!("key{}", key_index).as_bytes().to_vec();
 
             if key_index > delete_threshold {
@@ -1469,7 +1469,7 @@ mod tests {
         let store = Store::new(opts).expect("should reopen store");
 
         for key_index in 1..=num_keys {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let key = format!("key{}", key_index).as_bytes().to_vec();
 
             if key_index > clear_threshold {
@@ -1484,7 +1484,7 @@ mod tests {
 
         // Verify the results
         for key_index in 1..=num_keys {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let key = format!("key{}", key_index).as_bytes().to_vec();
 
             if key_index > clear_threshold {

--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -555,7 +555,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
             let val = txn.get(&key1).unwrap().unwrap();
@@ -566,7 +566,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
             let val = txn.get(&key2).unwrap().unwrap();
@@ -588,7 +588,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Retrieve the value associated with key3
             let val = txn.get(&key3).unwrap().unwrap();
@@ -630,7 +630,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Retrieve the value associated with key1
             let val = txn.get(&key1).unwrap().unwrap();
@@ -641,7 +641,7 @@ mod tests {
 
         {
             // Start a new read-only transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
 
             // Retrieve the value associated with key2
             let val = txn.get(&key2).unwrap().unwrap();

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -408,7 +408,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -443,7 +443,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -481,7 +481,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert_eq!(txn.get(&key).unwrap(), None);
         }
 
@@ -494,7 +494,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -532,7 +532,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert_eq!(txn.get(&key).unwrap(), None);
         }
 
@@ -541,7 +541,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -579,7 +579,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert_eq!(txn.get(&key).unwrap(), None);
         }
 
@@ -588,7 +588,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -632,7 +632,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert_eq!(txn.get(&key).unwrap(), None);
         }
 
@@ -645,7 +645,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -688,7 +688,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -730,7 +730,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }
@@ -769,7 +769,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert_eq!(txn.get(&key).unwrap(), None);
         }
 
@@ -782,7 +782,7 @@ mod tests {
             let key = Bytes::from(key);
 
             // Start a new read-write transaction (txn)
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
             assert_eq!(val, default_value);
         }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -805,7 +805,7 @@ mod tests {
         // Read the keys to the store
         for key in keys.iter() {
             // Start a new read transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn matches default_value
             assert_eq!(val, default_value.as_ref());
@@ -825,7 +825,7 @@ mod tests {
         // Read the keys to the store
         for key in keys.iter() {
             // Start a new read transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn matches default_value
             assert_eq!(val, default_value.as_ref());
@@ -984,7 +984,7 @@ mod tests {
                 let key = format!("key{}", j);
                 let value = format!("value{}", j);
                 let value = value.into_bytes();
-                let txn = store.begin().unwrap();
+                let mut txn = store.begin().unwrap();
                 let val = txn.get(key.as_bytes()).unwrap().unwrap();
 
                 assert_eq!(val, value);
@@ -1141,7 +1141,7 @@ mod tests {
 
         // Read the keys from the store
         for key in keys.iter() {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -1162,7 +1162,7 @@ mod tests {
 
         // Read the keys from the store
         for key in keys.iter() {
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             assert_eq!(val, default_value.as_ref());
         }
@@ -1197,7 +1197,7 @@ mod tests {
             let store = Store::new(opts.clone()).expect("should create store");
 
             // Test that the item is still in the store
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap();
 
             assert_eq!(val.unwrap(), value);
@@ -1243,7 +1243,7 @@ mod tests {
             let store = Store::new(opts.clone()).expect("should create store");
 
             // Test that the item is still in the store
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap();
 
             if should_exist {
@@ -1343,7 +1343,7 @@ mod tests {
         }
 
         let store = Store::new(opts.clone()).expect("should create store");
-        let txn = store.begin().unwrap();
+        let mut txn = store.begin().unwrap();
 
         let mut key_order: Vec<usize> = (0..num_elements).collect();
         key_order.shuffle(&mut rand::thread_rng());
@@ -1407,7 +1407,7 @@ mod tests {
         // Read the keys to the store
         for key in keys.iter() {
             // Start a new read transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             let val = txn.get(key).unwrap().unwrap();
             // Assert that the value retrieved in txn matches default_value
             assert_eq!(val, default_value.as_ref());
@@ -1421,7 +1421,7 @@ mod tests {
         // No keys should be found in the store
         for key in keys.iter() {
             // Start a new read transaction
-            let txn = store.begin().unwrap();
+            let mut txn = store.begin().unwrap();
             assert!(txn.get(key).unwrap().is_none());
         }
     }
@@ -1487,7 +1487,7 @@ mod tests {
 
         let reopened_store = Store::new(opts).expect("should reopen store");
         for key in keys.iter() {
-            let txn = reopened_store.begin().unwrap();
+            let mut txn = reopened_store.begin().unwrap();
             assert!(txn.get(key).unwrap().is_none());
         }
     }


### PR DESCRIPTION
Using a mutex seems to be too big of a price for `Transaction::get` with immutable `&self`.  We are already using mutable transactions everywhere, so there is no loss of functionality here.

Tested with SurrealDB.