### PR TITLE
Snapshots do not need start_ts

### DIFF
--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -159,7 +159,7 @@ impl SnapshotIsolation {
     /// are still valid in the latest snapshot, and if the timestamp of the read keys matches the timestamp
     /// of the latest snapshot. If the timestamp does not match, then there is a conflict.
     pub(crate) fn new_commit_ts(&self, txn: &mut Transaction) -> Result<u64> {
-        let current_snapshot = Snapshot::take(txn.core.clone(), self.read_ts())?;
+        let current_snapshot = Snapshot::take(txn.core.clone())?;
         let read_set = txn.read_set.lock();
 
         for entry in read_set.iter() {

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -33,7 +33,6 @@ use crate::storage::{
         snapshot::Snapshot,
         stats::StorageStats,
         transaction::{Durability, Mode, Transaction},
-        util::now,
     },
     log::{Aol, Error as LogError, MultiSegmentReader, Options as LogOptions, SegmentRef},
 };
@@ -184,7 +183,7 @@ impl Store {
     /// Returns a point-in-time snapshot of the store.
     pub fn get_snapshot(&self) -> Result<Snapshot> {
         let core = self.inner.as_ref().unwrap().core.clone();
-        let snapshot = Snapshot::take(core, now())?;
+        let snapshot = Snapshot::take(core)?;
         Ok(snapshot)
     }
 }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -176,7 +176,7 @@ impl Transaction {
 
         let mut snapshot = None;
         if !mode.is_write_only() {
-            snapshot = Some(RwLock::new(Snapshot::take(core.clone(), now())?));
+            snapshot = Some(RwLock::new(Snapshot::take(core.clone())?));
         }
 
         Ok(Self {
@@ -415,7 +415,7 @@ impl Transaction {
 
             // Apply all filters. If any filter fails, skip this key and continue with the next one.
             for filter in &FILTERS {
-                if filter.apply(&val_ref, self.read_ts).is_err() {
+                if filter.apply(&val_ref).is_err() {
                     continue 'outer;
                 }
             }
@@ -738,7 +738,7 @@ impl Transaction {
 
             // Apply all filters. If any filter fails, skip this key and continue with the next one.
             for filter in &FILTERS {
-                if filter.apply(&val_ref, ts).is_err() {
+                if filter.apply(&val_ref).is_err() {
                     continue 'outer;
                 }
             }


### PR DESCRIPTION
`Snapshot::start_ts` is confusing because it can lead to using `now()` for getting the value which is clearly wrong. 
It's actually not used at all, since the snapshot object implicitly records the version/timestamp as the largest version stored in the root node.

Tested with SurrealDB.