### PR TITLE
chore: rename delete/clear to hard/soft delete

### DIFF
--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -498,7 +498,7 @@ mod tests {
         // Delete the first 5 keys from the store
         for key in keys.iter().take(num_keys_to_delete) {
             let mut txn = store.begin().unwrap();
-            txn.delete(key).unwrap();
+            txn.hard_delete(key).unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -560,7 +560,7 @@ mod tests {
         let num_keys_to_delete = num_keys_to_write / 4;
         for key in keys.iter().take(num_keys_to_delete) {
             let mut txn = store.begin().unwrap();
-            txn.delete(key).unwrap();
+            txn.hard_delete(key).unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -772,7 +772,7 @@ mod tests {
         // Delete selected keys
         for key in &keys_to_delete {
             let mut txn = store.begin().unwrap();
-            txn.delete(key).unwrap();
+            txn.hard_delete(key).unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -917,7 +917,7 @@ mod tests {
             let mut txn = store
                 .begin()
                 .expect("Failed to begin transaction for deletion");
-            txn.delete(key).expect("Failed to delete key");
+            txn.hard_delete(key).expect("Failed to delete key");
             txn.commit().await.expect("Failed to commit deletion");
         }
 
@@ -983,7 +983,7 @@ mod tests {
             let mut txn = store
                 .begin()
                 .expect("Failed to begin transaction for deletion");
-            txn.delete(key).expect("Failed to delete key");
+            txn.hard_delete(key).expect("Failed to delete key");
             txn.commit().await.expect("Failed to commit deletion");
         }
 
@@ -1058,7 +1058,7 @@ mod tests {
                 let mut txn = store
                     .begin()
                     .expect("Failed to begin transaction for deletion");
-                txn.delete(key).expect("Failed to delete key");
+                txn.hard_delete(key).expect("Failed to delete key");
                 txn.commit().await.expect("Failed to commit deletion");
             }
         }
@@ -1157,7 +1157,7 @@ mod tests {
         {
             let mut txn = store.begin().unwrap();
             // Insert a key with two versions, where the last one is marked as deleted
-            txn.delete(b"key1").unwrap(); // Second version marked as deleted
+            txn.hard_delete(b"key1").unwrap(); // Second version marked as deleted
             txn.commit().await.unwrap();
         }
 
@@ -1357,7 +1357,7 @@ mod tests {
                 // Mark the last version as deleted for keys above the delete_threshold in its own transaction
                 if key_index > delete_threshold {
                     let mut txn = store.begin().unwrap();
-                    txn.delete(&key).unwrap();
+                    txn.hard_delete(&key).unwrap();
                     txn.commit().await.unwrap();
                 }
             }
@@ -1453,7 +1453,7 @@ mod tests {
                 // Mark the last version as deleted for keys above the clear_threshold in its own transaction
                 if key_index > clear_threshold {
                     let mut txn = store.begin().unwrap();
-                    txn.clear(&key).unwrap();
+                    txn.soft_delete(&key).unwrap();
                     txn.commit().await.unwrap();
                 }
             }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -1145,7 +1145,7 @@ mod tests {
         // Delete the keys from the store
         for key in keys.iter() {
             let mut txn = store.begin().unwrap();
-            txn.delete(key).unwrap();
+            txn.hard_delete(key).unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -1474,7 +1474,7 @@ mod tests {
         // Delete the first 5 keys from the store
         for key in keys.iter() {
             let mut txn = store.begin().unwrap();
-            txn.delete(key).unwrap();
+            txn.hard_delete(key).unwrap();
             txn.commit().await.unwrap();
         }
 

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -225,8 +225,9 @@ impl Transaction {
         Ok(())
     }
 
-    // Delete all the versions of a key. This is a hard delete.
-    pub fn delete(&mut self, key: &[u8]) -> Result<()> {
+    /// Delete all the versions of a key. This is a hard delete.
+    /// This will remove the key from the index and disk.
+    pub fn hard_delete(&mut self, key: &[u8]) -> Result<()> {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);
         entry.mark_delete();
@@ -234,8 +235,10 @@ impl Transaction {
         Ok(())
     }
 
-    /// Clear the key but not delete it. This is a soft delete.
-    pub fn clear(&mut self, key: &[u8]) -> Result<()> {
+    /// Mark all versions of a key as deleted. This is a soft delete,
+    /// and does not remove the key from the index, or disk, rather
+    /// just marks it as deleted, and the key will remain hidden.
+    pub fn soft_delete(&mut self, key: &[u8]) -> Result<()> {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);
         entry.mark_tombstone();
@@ -899,7 +902,7 @@ mod tests {
         {
             // Start a read-only transaction (txn)
             let mut txn = store.begin().unwrap();
-            txn.delete(&key1).unwrap();
+            txn.hard_delete(&key1).unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -1003,7 +1006,7 @@ mod tests {
             let mut txn2 = store.begin().unwrap();
             let mut txn3 = store.begin().unwrap();
 
-            txn2.delete(&key).unwrap();
+            txn2.hard_delete(&key).unwrap();
             assert!(txn2.commit().await.is_ok());
 
             assert!(txn3.get(&key).is_ok());
@@ -1155,7 +1158,7 @@ mod tests {
             let mut txn2 = store.begin().unwrap();
             let mut txn3 = store.begin().unwrap();
 
-            txn2.delete(&key4).unwrap();
+            txn2.hard_delete(&key4).unwrap();
             txn2.commit().await.unwrap();
 
             let range = "key1".as_bytes()..="key5".as_bytes();
@@ -1199,7 +1202,7 @@ mod tests {
             // Start a new read-write transaction (txn1)
             let mut txn1 = store.begin().unwrap();
             txn1.set(&key1, &value1).unwrap();
-            txn1.delete(&key1).unwrap();
+            txn1.hard_delete(&key1).unwrap();
             let res = txn1.get(&key1).unwrap();
             assert!(res.is_none());
             txn1.commit().await.unwrap();
@@ -1482,7 +1485,7 @@ mod tests {
             assert_eq!(res[0].1, value1);
             assert_eq!(res[1].1, value2);
 
-            txn2.delete(&key2).unwrap();
+            txn2.hard_delete(&key2).unwrap();
             txn1.commit().await.unwrap();
 
             let range = "k1".as_bytes()..="k3".as_bytes();
@@ -1601,7 +1604,7 @@ mod tests {
 
             txn2.commit().await.unwrap();
 
-            txn1.delete(&key2).unwrap();
+            txn1.hard_delete(&key2).unwrap();
             assert!(txn1.get(&key2).unwrap().is_none());
             assert!(match txn1.commit().await {
                 Err(err) => {
@@ -1642,7 +1645,7 @@ mod tests {
 
             txn2.set(&key1, &value3).unwrap();
 
-            txn1.delete(&key2).unwrap();
+            txn1.hard_delete(&key2).unwrap();
 
             txn2.set(&key2, &value4).unwrap();
 
@@ -1819,7 +1822,7 @@ mod tests {
             // Start a read-only transaction (txn)
             let mut txn = store.begin().unwrap();
             txn.get(&key1).unwrap();
-            txn.delete(&key1).unwrap();
+            txn.hard_delete(&key1).unwrap();
             let range = "k1".as_bytes()..="k3".as_bytes();
             let results = txn.scan(range, None).unwrap();
             assert_eq!(results.len(), 0);
@@ -1977,7 +1980,7 @@ mod tests {
                 98, 117, 115, 101, 114, 0,
             ]))
             .unwrap();
-            txn3.delete(&Bytes::copy_from_slice(&[
+            txn3.hard_delete(&Bytes::copy_from_slice(&[
                 47, 42, 116, 101, 115, 116, 45, 110, 115, 0, 42, 48, 49, 72, 80, 54, 72, 71, 72,
                 50, 50, 51, 89, 82, 49, 54, 51, 90, 52, 78, 56, 72, 69, 90, 80, 74, 69, 0, 42, 117,
                 115, 101, 114, 0, 42, 0, 0, 0, 1, 106, 111, 104, 110, 0,
@@ -2105,7 +2108,7 @@ mod tests {
         {
             // Start another read-write transaction (txn2)
             let mut txn2 = store.begin().unwrap();
-            txn2.delete(&key1).unwrap();
+            txn2.hard_delete(&key1).unwrap();
             txn2.commit().await.unwrap();
         }
 
@@ -2162,7 +2165,7 @@ mod tests {
         // Clear the key in a separate transaction
         {
             let mut txn = store.begin().unwrap();
-            txn.clear(&key).unwrap();
+            txn.soft_delete(&key).unwrap();
             txn.commit().await.unwrap();
         }
 


### PR DESCRIPTION
## Description

This PR renames the delete/clear method to hard_delete and soft_delete.

`hard_delete`: will remove the key (and it's versions) from the index, and disk upon compaction.
`soft_delete`: will not remove the key (and it's versions) from the index, and disk upon compaction. It will just mark it as hidden.