### PR TITLE
Feat/add scan all versions api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e200af7cb5302b8078b2bcf49501b06fd5727b33553d72988fe3a63987e85e"
+checksum = "1a8d5a909a58ae4ed6612e7efef7c70dcca222721c48b20ddbe55bc4ae06e07c"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.5.0"
+vart = "0.6.0"
 revision = "0.10.0"
 
 [dev-dependencies]

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -63,6 +63,9 @@ impl Mode {
 /// ScanResult is a tuple containing the key, value, timestamp, and commit timestamp of a key-value pair.
 pub type ScanResult = (Vec<u8>, Vec<u8>, u64, u64);
 
+/// ScanResult is a tuple containing the key, value, timestamp, and info about whether the key is deleted.
+pub type ScanVersionResult = (Vec<u8>, Vec<u8>, u64, bool);
+
 #[derive(Default, Debug, Copy, Clone)]
 pub enum Durability {
     /// Commits with this durability level are guaranteed to be persistent eventually. The data
@@ -795,7 +798,7 @@ impl Transaction {
         &self,
         range: R,
         limit: Option<usize>,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>, u64, bool)>>
+    ) -> Result<Vec<ScanVersionResult>>
     where
         R: RangeBounds<&'b [u8]>,
     {
@@ -807,10 +810,10 @@ impl Transaction {
 
         // Get a range iterator for the specified range.
         let snap = self.snapshot.as_ref().unwrap().read();
-        let ranger = snap.range(range);
+        let ranger = snap.range_with_versions(range);
 
         // Iterate over the keys in the range.
-        for (key, value, version, ts) in ranger {
+        for (key, value, _, ts) in ranger {
             // If a limit is set and we've already got enough results, break the loop.
             if let Some(limit) = limit {
                 if results.len() >= limit {
@@ -829,6 +832,8 @@ impl Transaction {
 
             // Add the key, value, version, and deletion status to the results vector.
             let mut key = key;
+
+            // Remove the trailing `\0`.
             key.truncate(key.len() - 1);
             results.push((key, v, *ts, is_deleted));
         }
@@ -2577,5 +2582,352 @@ mod tests {
             tx_reader.read_into(&mut log_rec),
             Err(Error::LogError(LogError::Eof))
         ),);
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_single_key_single_version() {
+        let (store, _) = create_store(false);
+        let key = Bytes::from("key1");
+        let value = Bytes::from("value1");
+
+        let mut txn = store.begin().unwrap();
+        txn.set_at_ts(&key, &value, 1).unwrap();
+        txn.commit().await.unwrap();
+
+        let range = key.as_ref()..=key.as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        assert_eq!(results.len(), 1);
+        let (k, v, version, is_deleted) = &results[0];
+        assert_eq!(k, &key);
+        assert_eq!(v, &value);
+        assert_eq!(*version, 1);
+        assert!(!(*is_deleted));
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_single_key_multiple_versions() {
+        let (store, _) = create_store(false);
+        let key = Bytes::from("key1");
+
+        // Insert multiple versions of the same key
+        let values = [
+            Bytes::from("value1"),
+            Bytes::from("value2"),
+            Bytes::from("value3"),
+        ];
+
+        for (i, value) in values.iter().enumerate() {
+            let mut txn = store.begin().unwrap();
+            let version = (i + 1) as u64; // Incremental version
+            txn.set_at_ts(&key, value, version).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let range = key.as_ref()..=key.as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        // Verify that the output contains all the versions of the key
+        assert_eq!(results.len(), values.len());
+        for (i, (k, v, version, is_deleted)) in results.iter().enumerate() {
+            assert_eq!(k, &key);
+            assert_eq!(v, &values[i]);
+            assert_eq!(*version, (i + 1) as u64);
+            assert!(!(*is_deleted));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_multiple_keys_single_version_each() {
+        let (store, _) = create_store(false);
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+        let value = Bytes::from("value1");
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.set_at_ts(key, &value, 1).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        assert_eq!(results.len(), keys.len());
+        for (i, (k, v, version, is_deleted)) in results.iter().enumerate() {
+            assert_eq!(k, &keys[i]);
+            assert_eq!(v, &value);
+            assert_eq!(*version, 1);
+            assert!(!(*is_deleted));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_multiple_keys_multiple_versions_each() {
+        let (store, _) = create_store(false);
+
+        // Define a range of keys
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+
+        // Insert multiple versions for each key
+        let values = [
+            Bytes::from("value1"),
+            Bytes::from("value2"),
+            Bytes::from("value3"),
+        ];
+
+        for key in &keys {
+            for (i, value) in values.iter().enumerate() {
+                let mut txn = store.begin().unwrap();
+                let version = (i + 1) as u64; // Incremental version
+                txn.set_at_ts(key, value, version).unwrap();
+                txn.commit().await.unwrap();
+            }
+        }
+
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        let mut expected_results = Vec::new();
+        for key in &keys {
+            for (i, value) in values.iter().enumerate() {
+                expected_results.push((key.clone(), value.clone(), (i + 1) as u64, false));
+            }
+        }
+
+        assert_eq!(results.len(), expected_results.len());
+        for (result, expected) in results.iter().zip(expected_results.iter()) {
+            let (k, v, version, is_deleted) = result;
+            let (expected_key, expected_value, expected_version, expected_is_deleted) = expected;
+            assert_eq!(k, expected_key);
+            assert_eq!(v, expected_value);
+            assert_eq!(*version, *expected_version);
+            assert_eq!(*is_deleted, *expected_is_deleted);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_deleted_records() {
+        let (store, _) = create_store(false);
+        let key = Bytes::from("key1");
+        let value = Bytes::from("value1");
+
+        let mut txn = store.begin().unwrap();
+        txn.set_at_ts(&key, &value, 1).unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = store.begin().unwrap();
+        txn.soft_delete(&key).unwrap();
+        txn.commit().await.unwrap();
+
+        let range = key.as_ref()..=key.as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        assert_eq!(results.len(), 2);
+        let (k, v, version, is_deleted) = &results[0];
+        assert_eq!(k, &key);
+        assert_eq!(v, &value);
+        assert_eq!(*version, 1);
+        assert!(!(*is_deleted));
+
+        let (k, v, _, is_deleted) = &results[1];
+        assert_eq!(k, &key);
+        assert_eq!(v, &Bytes::new());
+        assert!(*is_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_multiple_keys_single_version_each_deleted() {
+        let (store, _) = create_store(false);
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+        let value = Bytes::from("value1");
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.set_at_ts(key, &value, 1).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.soft_delete(key).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        assert_eq!(results.len(), keys.len() * 2);
+        for (i, (k, v, version, is_deleted)) in results.iter().enumerate() {
+            let key_index = i / 2;
+            let is_deleted_version = i % 2 == 1;
+            assert_eq!(k, &keys[key_index]);
+            if is_deleted_version {
+                assert_eq!(v, &Bytes::new());
+                assert!(*is_deleted);
+            } else {
+                assert_eq!(v, &value);
+                assert_eq!(*version, 1);
+                assert!(!(*is_deleted));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_multiple_keys_multiple_versions_each_deleted() {
+        let (store, _) = create_store(false);
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+        let values = [
+            Bytes::from("value1"),
+            Bytes::from("value2"),
+            Bytes::from("value3"),
+        ];
+
+        for key in &keys {
+            for (i, value) in values.iter().enumerate() {
+                let mut txn = store.begin().unwrap();
+                let version = (i + 1) as u64;
+                txn.set_at_ts(key, value, version).unwrap();
+                txn.commit().await.unwrap();
+            }
+        }
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.soft_delete(key).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        let mut expected_results = Vec::new();
+        for key in &keys {
+            for (i, value) in values.iter().enumerate() {
+                expected_results.push((key.clone(), value.clone(), (i + 1) as u64, false));
+            }
+            expected_results.push((key.clone(), Bytes::new(), 0, true));
+        }
+
+        assert_eq!(results.len(), expected_results.len());
+        for (result, expected) in results.iter().zip(expected_results.iter()) {
+            let (k, v, version, is_deleted) = result;
+            let (expected_key, expected_value, expected_version, expected_is_deleted) = expected;
+            assert_eq!(k, expected_key);
+            assert_eq!(v, expected_value);
+            // Check version only if the record is not deleted
+            // This is because a soft-deleted record has version which is
+            // the commit timestamp of the transaction, and do not want to
+            // make the test complex by predicting the exact value.
+            if !expected_is_deleted {
+                assert_eq!(*version, *expected_version);
+            }
+            assert_eq!(*is_deleted, *expected_is_deleted);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_soft_and_hard_delete() {
+        let (store, _) = create_store(false);
+        let key = Bytes::from("key1");
+        let value = Bytes::from("value1");
+
+        let mut txn = store.begin().unwrap();
+        txn.set_at_ts(&key, &value, 1).unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = store.begin().unwrap();
+        txn.soft_delete(&key).unwrap();
+        txn.commit().await.unwrap();
+
+        let mut txn = store.begin().unwrap();
+        txn.delete(&key).unwrap();
+        txn.commit().await.unwrap();
+
+        let range = key.as_ref()..=key.as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+
+        assert_eq!(results.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_range_boundaries() {
+        let (store, _) = create_store(false);
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+        let value = Bytes::from("value1");
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.set_at_ts(key, &value, 1).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        // Inclusive range
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+        assert_eq!(results.len(), keys.len());
+
+        // Exclusive range
+        let range = keys.first().unwrap().as_ref()..keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+        assert_eq!(results.len(), keys.len() - 1);
+
+        // Unbounded range
+        let range = ..;
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, None).unwrap();
+        assert_eq!(results.len(), keys.len());
+    }
+
+    #[tokio::test]
+    async fn test_scan_all_versions_with_limit() {
+        let (store, _) = create_store(false);
+        let keys = vec![
+            Bytes::from("key1"),
+            Bytes::from("key2"),
+            Bytes::from("key3"),
+        ];
+        let value = Bytes::from("value1");
+
+        for key in &keys {
+            let mut txn = store.begin().unwrap();
+            txn.set_at_ts(key, &value, 1).unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let range = keys.first().unwrap().as_ref()..=keys.last().unwrap().as_ref();
+        let txn = store.begin().unwrap();
+        let results = txn.scan_all_versions(range, Some(2)).unwrap();
+
+        assert_eq!(results.len(), 2);
     }
 }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -818,19 +818,14 @@ impl Transaction {
                 }
             }
 
-            // Create a new value reference and decode the value.
-            let mut val_ref = ValueRef::new(self.core.clone());
-            let val_bytes_ref: &Bytes = value;
-            val_ref.decode(*version, val_bytes_ref)?;
-
             // Determine if the record is soft deleted based on the metadata.
             let mut is_deleted = false;
-            if let Some(md) = val_ref.metadata() {
+            if let Some(md) = value.metadata() {
                 is_deleted = md.is_tombstone();
             }
 
             // Resolve the value reference to get the actual value.
-            let v = val_ref.resolve()?;
+            let v = value.resolve(&self.core)?;
 
             // Add the key, value, version, and deletion status to the results vector.
             let mut key = key;


### PR DESCRIPTION
## Description

This PR adds a `scan_all_versions` method to scan all the versions of the keys within the specified range.