### PR TITLE
Add a flag to disable versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1259,9 +1259,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8d5a909a58ae4ed6612e7efef7c70dcca222721c48b20ddbe55bc4ae06e07c"
+checksum = "5333f3d56808a1b86455429ba0c6d2451d6d8b935fcbacb4f7c9a59baaa7a25e"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -26,7 +26,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.6.0"
+vart = "0.6.1"
 revision = "0.10.0"
 
 [dev-dependencies]

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -40,6 +40,24 @@ impl Indexer {
         Ok(())
     }
 
+    pub fn insert_or_replace(
+        &mut self,
+        key: &mut VariableSizeKey,
+        value: IndexValue,
+        version: u64,
+        ts: u64,
+        check_version: bool,
+    ) -> Result<()> {
+        *key = key.terminate();
+        if check_version {
+            self.index.insert_or_replace(key, value, version, ts)?;
+        } else {
+            self.index
+                .insert_or_replace_unchecked(key, value, version, ts)?;
+        }
+        Ok(())
+    }
+
     pub fn delete(&mut self, key: &mut VariableSizeKey) {
         *key = key.terminate();
         self.index.remove(key);

--- a/src/storage/kv/option.rs
+++ b/src/storage/kv/option.rs
@@ -19,7 +19,7 @@ impl IsolationLevel {
     }
 }
 
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Options {
     // Required options.
@@ -43,6 +43,10 @@ pub struct Options {
 
     // Field to indicate whether the data should be stored completely in memory
     pub disk_persistence: bool, // If false, data will be stored completely in memory. If true, data will be stored on disk too.
+
+    // Used to enable or disable versioned values.
+    #[revision(start = 3)]
+    pub enable_versions: bool,
 }
 
 impl Default for Options {
@@ -56,6 +60,7 @@ impl Default for Options {
             max_value_cache_size: 100000,
             disk_persistence: true,
             max_compaction_segment_size: 1 << 30, // 1 GB
+            enable_versions: true,
         }
     }
 }
@@ -98,5 +103,6 @@ mod tests {
         assert_eq!(options.max_value_cache_size, 100000);
         assert_eq!(options.max_compaction_segment_size, 1 << 30);
         assert!(options.disk_persistence);
+        assert!(options.enable_versions);
     }
 }


### PR DESCRIPTION
Uses https://github.com/surrealdb/vart/pull/57

Add a new configuration flag to control whether versions are enabled or disabled. The default is enabled.
Tested with SurrealDB using `cargo make ci-api-integration-surrealkv` with versions and disk persistence disabled.