### PR TITLE
Fix: scan all versions limit should be restricted to unique keys

### DIFF
--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -3198,6 +3198,8 @@ mod tests {
         assert_eq!(results[2].0, key3);
         assert_eq!(results[2].1, value3);
     }
+
+    #[tokio::test]
     async fn test_scan_all_versions_with_subsets() {
         let (store, _) = create_store(false);
         let keys = vec![


### PR DESCRIPTION
## Description

This PR modifies `scan_all_versions` API to apply limit on unique set of keys and not number of records. This is to avoid reading partial versions and not being able to read the remaining