### PR TITLE
fix: sdb bug on hard delete and reinsert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,8 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "vart"
 version = "0.6.2"
-source = "git+https://github.com/surrealdb/vart?branch=chore/allow-creating-custom-snapshot#866626aee125d133c75b1aa7f56cea02f6392eb4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7fc7164de494edba1a18a45374052ed27ca9f35e35a4bc4b68b8284718ff89"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1259,9 +1259,8 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5333f3d56808a1b86455429ba0c6d2451d6d8b935fcbacb4f7c9a59baaa7a25e"
+version = "0.6.2"
+source = "git+https://github.com/surrealdb/vart?branch=chore/allow-creating-custom-snapshot#866626aee125d133c75b1aa7f56cea02f6392eb4"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = {git = "https://github.com/surrealdb/vart", branch = "chore/allow-creating-custom-snapshot"}
+vart = "0.6.2"
 revision = "0.10.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -26,7 +26,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.6.1"
+vart = {git = "https://github.com/surrealdb/vart", branch = "chore/allow-creating-custom-snapshot"}
 revision = "0.10.0"
 
 [dev-dependencies]

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -30,7 +30,7 @@ impl Indexer {
     ) -> Result<VartSnapshot<VariableSizeKey, IndexValue>> {
         self.index
             .create_snapshot_at_version(version)
-            .map_err(|e| Error::from(e))
+            .map_err(Error::from)
     }
 
     pub fn insert(

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use vart::{art::Tree as VartIndex, snapshot::Snapshot as VartSnapshot, VariableSizeKey};
 
-use crate::storage::kv::error::Result;
+use crate::storage::kv::error::{Error, Result};
 use crate::storage::kv::meta::Metadata;
 use crate::storage::kv::store::Core;
 
@@ -21,6 +21,16 @@ impl Indexer {
     /// Creates a snapshot of the current state of the index.
     pub(crate) fn snapshot(&self) -> VartSnapshot<VariableSizeKey, IndexValue> {
         self.index.create_snapshot()
+    }
+
+    /// Creates a snapshot of the current state of the index at a given version.
+    pub(crate) fn snapshot_at_version(
+        &self,
+        version: u64,
+    ) -> Result<VartSnapshot<VariableSizeKey, IndexValue>> {
+        self.index
+            .create_snapshot_at_version(version)
+            .map_err(|e| Error::from(e))
     }
 
     pub fn insert(

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -3091,4 +3091,36 @@ mod tests {
             txn.commit().await.unwrap();
         }
     }
+
+    #[tokio::test]
+    async fn test_scan_includes_entries_before_commit() {
+        let (store, _) = create_store(false);
+
+        // Define key-value pairs for the test
+        let key1 = Bytes::from("key1");
+        let key2 = Bytes::from("key2");
+        let key3 = Bytes::from("key3");
+        let value1 = Bytes::from("value1");
+        let value2 = Bytes::from("value2");
+        let value3 = Bytes::from("value3");
+
+        // Start a new read-write transaction (txn)
+        let mut txn = store.begin().unwrap();
+        txn.set(&key1, &value1).unwrap();
+        txn.set(&key2, &value2).unwrap();
+        txn.set(&key3, &value3).unwrap();
+
+        // Define the range for the scan
+        let range = "key1".as_bytes()..="key3".as_bytes();
+        let results = txn.scan(range, None).unwrap();
+
+        // Verify the results
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].0, key1);
+        assert_eq!(results[0].1, value1);
+        assert_eq!(results[1].0, key2);
+        assert_eq!(results[1].1, value2);
+        assert_eq!(results[2].0, key3);
+        assert_eq!(results[2].1, value3);
+    }
 }


### PR DESCRIPTION
## Description

Fixes a bug where scan after a hard_delete would create a read conflict. This is because snapshots created were always based on the vart version, which rolls back (or decreases) when a hard_delete occurs. 