### PR TITLE
Make store::read_ts() infallible

### DIFF
--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -21,7 +21,7 @@ impl Snapshot {
     pub(crate) fn take(store: &Core) -> Result<Self> {
         // Each snapshot is created at a version that is one greater than the current version.
         let index = store.indexer.read();
-        let version = store.read_ts()? + 1;
+        let version = store.read_ts() + 1;
         let snap = index.index.clone();
         Ok(Self { snap, version })
     }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -363,12 +363,8 @@ impl Core {
         })
     }
 
-    pub(crate) fn read_ts(&self) -> Result<u64> {
-        if self.is_closed() {
-            return Err(Error::StoreClosed);
-        }
-
-        Ok(self.oracle.read_ts())
+    pub(crate) fn read_ts(&self) -> u64 {
+        self.oracle.read_ts()
     }
 
     // The load_index function is responsible for loading the index from the log.

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -176,7 +176,7 @@ pub struct Transaction {
 impl Transaction {
     /// Prepare a new transaction in the given mode.
     pub fn new(core: Arc<Core>, mode: Mode) -> Result<Self> {
-        let mut read_ts = core.read_ts()?;
+        let mut read_ts = core.read_ts();
 
         let mut snapshot = None;
         if !mode.is_write_only() {


### PR DESCRIPTION
It's a utility method, high level logic like `Store::begin()` should take care of checking wether the store is open or closed.