### PR TITLE
chore: add test for concurrent inserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,9 +1258,9 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "vart"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d02665a2dd16898d28bd1d314b067a97365facca5c39c370d55822bcbbfb48"
+checksum = "1c92195d375eb94995afddeedfd7f246796eb60b85f727c538e42222c4c9b2d3"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.6.3"
+vart = "0.7.0"
 revision = "0.10.0"
 
 [dev-dependencies]

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -36,16 +36,17 @@ pub enum Error {
     ReceiveError(String),
     RevisionError(String),
     MismatchedSegmentID(u64, u64),
-    CompactionAlreadyInProgress,   // Compaction is in progress
-    MergeManifestMissing,          // The merge manifest is missing
-    CustomError(String),           // Custom error
-    InvalidOperation,              // Invalid operation
-    CompactionSegmentSizeTooSmall, // The segment size is too small for compaction
-    SegmentIdExceedsLastUpdated,   // The segment ID exceeds the last updated segment
-    TransactionMustBeReadOnly,     // The transaction must be read-only
-    TransactionWithoutSavepoint,   // The transaction does not have a savepoint set
-    MaxKVMetadataLengthExceeded,   // The maximum KV metadata length is exceeded
-    ChecksumMismatch(u32, u32),    // Checksum mismatch
+    CompactionAlreadyInProgress,    // Compaction is in progress
+    MergeManifestMissing,           // The merge manifest is missing
+    CustomError(String),            // Custom error
+    InvalidOperation,               // Invalid operation
+    CompactionSegmentSizeTooSmall,  // The segment size is too small for compaction
+    SegmentIdExceedsLastUpdated,    // The segment ID exceeds the last updated segment
+    TransactionMustBeReadOnly,      // The transaction must be read-only
+    TransactionWithoutSavepoint,    // The transaction does not have a savepoint set
+    MaxKVMetadataLengthExceeded,    // The maximum KV metadata length is exceeded
+    ChecksumMismatch(u32, u32),     // Checksum mismatch
+    SnapshotVersionIsOld(u64, u64), // The snapshot version is too old
 }
 
 // Implementation of Display trait for Error
@@ -113,6 +114,13 @@ impl fmt::Display for Error {
                 write!(
                     f,
                     "Checksum mismatch: expected={}, found={}",
+                    expected, found
+                )
+            }
+            Error::SnapshotVersionIsOld(expected, found) => {
+                write!(
+                    f,
+                    "Snapshot version is old: read_ts={}, index={}",
                     expected, found
                 )
             }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -3438,19 +3438,5 @@ mod tests {
 
         // Drop the store to simulate closing it
         store.close().await.unwrap();
-
-        // Create a new Core instance with VariableSizeKey after dropping the previous one
-        let mut opts = Options::new();
-        opts.dir = temp_dir.path().to_path_buf();
-        let store = Store::new(opts).expect("should create store");
-
-        // Verify that the keys are present in the store
-        let mut txn = store.begin_with_mode(crate::Mode::ReadOnly).unwrap();
-        for (key, value) in keys.iter().zip(values.iter()) {
-            let val = txn.get(key).unwrap().unwrap();
-            assert_eq!(val, value.as_ref());
-        }
-
-        store.close().await.unwrap();
     }
 }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -489,8 +489,7 @@ impl Transaction {
 
         // Check if the transaction is written to the transaction log.
         let done = done.unwrap();
-        let ret: std::result::Result<std::result::Result<(), Error>, async_channel::RecvError> =
-            done.recv().await;
+        let ret = done.recv().await;
         if let Err(err) = ret {
             oracle.committed_upto(tx_id);
             return Err(err.into());

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -3380,7 +3380,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_transactions() {
-        let (store, temp_dir) = create_store(false);
+        let (store, _) = create_store(false);
         let store = Arc::new(store);
 
         // Define key-value pairs for the test
@@ -3400,7 +3400,7 @@ mod tests {
 
         // Spawn concurrent transactions
         for (key, value) in keys.iter().zip(values.iter()) {
-            let store = Arc::clone(&store); // Clone the Arc to increment the reference count
+            let store = Arc::clone(&store);
             let key = key.clone();
             let value = value.clone();
 


### PR DESCRIPTION
## Description

This PR adds the following:

1) Adds check if the snapshot is not lesser than index version
2) Modifies Transaction::commit to return (tx_id, commit_ts) for verification
3) Add basic test to verify if concurrent transactions committed have incremental txn ids


Addresses https://github.com/surrealdb/surrealkv/issues/108