### PR TITLE
chore: use tokio semaphore instead of rwlock for critical section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "nanoid",
+ "num_cpus",
  "parking_lot",
  "quick_cache",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ fastrand = "2.0.1"
 libc = "0.2.155"
 fmmap = "0.3.3"
 memmap2 = "0.9.4"
+num_cpus = "1.16"
+
 
 [[bench]]
 name = "store_bench"

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -113,28 +113,36 @@ fn sequential_insert_read(c: &mut Criterion) {
 }
 
 fn concurrent_insert(c: &mut Criterion) {
-    let item_count = 100_000;
+    let total_items = 100_000;
+    // Test different thread counts from 1 to num_cpus
+    let thread_counts = vec![1, 2, 4, 8, num_cpus::get() as u32];
 
-    let mut group = c.benchmark_group("inserts");
+    let mut group = c.benchmark_group("concurrent_inserts");
     group.sample_size(10);
-    group.throughput(criterion::Throughput::Elements(item_count as u64));
+    group.throughput(criterion::Throughput::Elements(total_items as u64));
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(8)
-        .enable_all()
-        .build()
-        .unwrap();
+    for &thread_count in &thread_counts {
+        // Create a runtime with the specific thread count
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(thread_count as usize)
+            .enable_all()
+            .build()
+            .unwrap();
 
-    let db = rt.block_on(async {
-        let mut opts = Options::new();
-        opts.dir = create_temp_directory().path().to_path_buf();
-        Arc::new(Store::new(opts).expect("should create store"))
-    });
+        let db = rt.block_on(async {
+            let mut opts = Options::new();
+            opts.dir = create_temp_directory().path().to_path_buf();
+            Arc::new(Store::new(opts).expect("should create store"))
+        });
 
-    {
-        let thread_count = 8_u32;
+        // Calculate operations per thread to maintain constant total work
+        let ops_per_thread = total_items / thread_count;
+
         group.bench_function(
-            format!("{} inserts ({} threads)", item_count, thread_count),
+            format!(
+                "threads={} total_ops={} ops_per_thread={}",
+                thread_count, total_items, ops_per_thread
+            ),
             |b| {
                 b.iter(|| {
                     let mut handles = vec![];
@@ -144,7 +152,7 @@ fn concurrent_insert(c: &mut Criterion) {
 
                         let handle = rt.spawn(async move {
                             let mut txn = db.begin().unwrap();
-                            for _ in 0..(item_count / thread_count) {
+                            for _ in 0..ops_per_thread {
                                 let key = nanoid::nanoid!();
                                 let value = nanoid::nanoid!();
                                 txn.set(key.as_bytes(), value.as_bytes()).unwrap();
@@ -155,19 +163,25 @@ fn concurrent_insert(c: &mut Criterion) {
                         handles.push(handle);
                     }
 
-                    for handle in handles {
-                        rt.block_on(handle).unwrap();
-                    }
+                    // Wait for all threads to complete
+                    rt.block_on(async {
+                        for handle in handles {
+                            handle.await.unwrap();
+                        }
+                    })
                 })
             },
         );
+
+        // Cleanup
+        rt.block_on(async {
+            drop(db);
+        });
+
+        rt.shutdown_background();
     }
 
-    rt.block_on(async {
-        drop(db);
-    });
-
-    rt.shutdown_background();
+    group.finish();
 }
 
 criterion_group!(benches_sequential, bulk_insert, sequential_insert_read);

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -68,7 +68,7 @@ impl StoreInner {
 
         // Lock the oracle to prevent operations during compaction
         let oracle = self.core.oracle.clone();
-        let oracle_lock = oracle.write_lock.lock().await;
+        let oracle_lock = oracle.commit_lock.acquire().await?;
 
         // Rotate the commit log and get the new segment ID
         let mut clog = self.core.clog.as_ref().unwrap().write();

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -46,6 +46,7 @@ pub enum Error {
     TransactionWithoutSavepoint,   // The transaction does not have a savepoint set
     MaxKVMetadataLengthExceeded,   // The maximum KV metadata length is exceeded
     ChecksumMismatch(u32, u32),    // Checksum mismatch
+    CommitLockError(String),       // Error acquiring commit lock
 }
 
 // Implementation of Display trait for Error
@@ -116,6 +117,7 @@ impl fmt::Display for Error {
                     expected, found
                 )
             }
+            Error::CommitLockError(err) => write!(f, "Commit lock error: {}", err),
         }
     }
 }
@@ -163,5 +165,11 @@ impl From<async_channel::RecvError> for Error {
 impl From<revision::Error> for Error {
     fn from(err: revision::Error) -> Self {
         Error::RevisionError(err.to_string())
+    }
+}
+
+impl From<tokio::sync::AcquireError> for Error {
+    fn from(err: tokio::sync::AcquireError) -> Self {
+        Error::CommitLockError(format!("AcquireError: {:?}", err))
     }
 }

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -457,7 +457,7 @@ impl Transaction {
 
         // Lock the oracle to serialize commits to the transaction log.
         let oracle = self.core.oracle.clone();
-        let write_ch_lock = oracle.write_lock.lock().await;
+        let write_ch_lock = oracle.commit_lock.acquire().await?;
 
         // Prepare for the commit by getting a transaction ID.
         let tx_id = self.prepare_commit()?;


### PR DESCRIPTION
## Description

This PR explores using tokio semaphore instead of RWLock in oracle for the critical section

https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html