### PR TITLE
Allow keys without zero byte terminator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
  "humansize",
  "indicatif",
  "serde_json",
- "surrealkv 0.5.4",
+ "surrealkv 0.6.1",
 ]
 
 [[package]]
@@ -1403,7 +1403,7 @@ dependencies = [
  "surrealkv 0.4.4",
  "tempdir",
  "tokio",
- "vart 0.7.0",
+ "vart 0.8.0",
  "walkdir",
  "wasm-bindgen-futures",
 ]
@@ -1500,9 +1500,9 @@ checksum = "52d02665a2dd16898d28bd1d314b067a97365facca5c39c370d55822bcbbfb48"
 
 [[package]]
 name = "vart"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c92195d375eb94995afddeedfd7f246796eb60b85f727c538e42222c4c9b2d3"
+checksum = "c9a2ea22a0e064164cecaf12fe060ba3806598ba3f1cfad6b7a9ba4167d5bbab"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.7.0"
+vart = "0.8.0"
 revision = "0.10.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
@@ -55,4 +55,8 @@ walkdir = "2.5.0"
 
 [[bench]]
 name = "store_bench"
+harness = false
+
+[[bench]]
+name = "load_bench"
 harness = false

--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -112,8 +112,6 @@ impl StoreInner {
                                ts: u64,
                                metadata: Option<Metadata>|
          -> Result<()> {
-            let mut key = key;
-            key.truncate(key.len() - 1);
             let mut entry = Entry::new(&key, &value);
             entry.set_ts(ts);
 

--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -31,7 +31,6 @@ impl Indexer {
         ts: u64,
         check_version: bool,
     ) -> Result<()> {
-        *key = key.terminate();
         if check_version {
             self.index.insert(key, value, version, ts)?;
         } else {
@@ -48,7 +47,6 @@ impl Indexer {
         ts: u64,
         check_version: bool,
     ) -> Result<()> {
-        *key = key.terminate();
         if check_version {
             self.index.insert_or_replace(key, value, version, ts)?;
         } else {
@@ -59,7 +57,6 @@ impl Indexer {
     }
 
     pub fn delete(&mut self, key: &mut VariableSizeKey) {
-        *key = key.terminate();
         self.index.remove(key);
     }
 

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -270,7 +270,7 @@ fn key_in_range(
     range_start: &Bound<VariableSizeKey>,
     range_end: &Bound<VariableSizeKey>,
 ) -> bool {
-    let key = VariableSizeKey::from_slice_with_termination(key);
+    let key = VariableSizeKey::from_slice(key);
 
     let start_inclusive = match &range_start {
         Bound::Included(start) => key >= *start,

--- a/src/storage/kv/snapshot.rs
+++ b/src/storage/kv/snapshot.rs
@@ -43,10 +43,6 @@ impl Snapshot {
 
     /// Set a key-value pair into the snapshot.
     pub(crate) fn set(&mut self, key: &VariableSizeKey, value: IndexValue) {
-        // TODO: need to fix this to avoid cloning the key
-        // This happens because the VariableSizeKey transfrom from
-        // a &[u8] does not terminate the key with a null byte.
-        let key = &key.terminate();
         self.snap
             .insert(key, value, self.version, now())
             .expect("incorrect snapshot version");
@@ -54,10 +50,6 @@ impl Snapshot {
 
     #[allow(unused)]
     pub(crate) fn delete(&mut self, key: &VariableSizeKey) -> bool {
-        // TODO: need to fix this to avoid cloning the key
-        // This happens because the VariableSizeKey transfrom from
-        // a &[u8] does not terminate the key with a null byte.
-        let key = &key.terminate();
         self.snap.remove(key)
     }
 
@@ -71,10 +63,6 @@ impl Snapshot {
 
     /// Retrieves the latest value associated with the given key from the snapshot.
     pub(crate) fn get(&self, key: &VariableSizeKey) -> Result<(IndexValue, u64)> {
-        // TODO: need to fix this to avoid cloning the key
-        // This happens because the VariableSizeKey transfrom from
-        // a &[u8] does not terminate the key with a null byte.
-        let key = &key.terminate();
         let (snap_val, version, _) = self.snap.get(key, self.version).ok_or(Error::KeyNotFound)?;
         let val = self.apply_filters(snap_val, &FILTERS)?;
         Ok((val, version))
@@ -82,7 +70,6 @@ impl Snapshot {
 
     /// Retrieves the value associated with the given key at the given timestamp from the snapshot.
     pub(crate) fn get_at_ts(&self, key: &VariableSizeKey, ts: u64) -> Result<IndexValue> {
-        let key = &key.terminate();
         let (val, _, _) = self.snap.get_at_ts(key, ts).ok_or(Error::KeyNotFound)?;
         self.apply_filters(val, &FILTERS)
     }
@@ -92,8 +79,6 @@ impl Snapshot {
         &self,
         key: &VariableSizeKey,
     ) -> Result<Vec<(IndexValue, u64)>> {
-        let key = &key.terminate();
-
         let mut results = Vec::new();
 
         let items = self

--- a/src/storage/kv/util.rs
+++ b/src/storage/kv/util.rs
@@ -74,17 +74,13 @@ where
 {
     // Step 2: Apply the conversion logic for both start and end bounds
     let start_bound = match range.start_bound() {
-        Bound::Included(start) => {
-            Bound::Included(VariableSizeKey::from_slice_with_termination(start))
-        }
-        Bound::Excluded(start) => {
-            Bound::Excluded(VariableSizeKey::from_slice_with_termination(start))
-        }
+        Bound::Included(start) => Bound::Included(VariableSizeKey::from_slice(start)),
+        Bound::Excluded(start) => Bound::Excluded(VariableSizeKey::from_slice(start)),
         Bound::Unbounded => Bound::Unbounded,
     };
     let end_bound = match range.end_bound() {
-        Bound::Included(end) => Bound::Included(VariableSizeKey::from_slice_with_termination(end)),
-        Bound::Excluded(end) => Bound::Excluded(VariableSizeKey::from_slice_with_termination(end)),
+        Bound::Included(end) => Bound::Included(VariableSizeKey::from_slice(end)),
+        Bound::Excluded(end) => Bound::Excluded(VariableSizeKey::from_slice(end)),
         Bound::Unbounded => Bound::Unbounded,
     };
     (start_bound, end_bound)


### PR DESCRIPTION
This integrates https://github.com/surrealdb/vart/pull/69

Will need to update `Cargo.toml` once the `vart` PR is merged.