### PR TITLE
chore: add option to skip crc verification check

### DIFF
--- a/src/storage/kv/option.rs
+++ b/src/storage/kv/option.rs
@@ -19,7 +19,7 @@ impl IsolationLevel {
     }
 }
 
-#[revisioned(revision = 3)]
+#[revisioned(revision = 4)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Options {
     // Required options.
@@ -47,6 +47,9 @@ pub struct Options {
     // Used to enable or disable versioned values.
     #[revision(start = 3)]
     pub enable_versions: bool,
+
+    #[revision(start = 4)]
+    pub skip_checksum_verification: bool, // Skip checksum verification for read operations.
 }
 
 impl Default for Options {
@@ -61,6 +64,7 @@ impl Default for Options {
             disk_persistence: true,
             max_compaction_segment_size: 1 << 30, // 1 GB
             enable_versions: true,
+            skip_checksum_verification: false,
         }
     }
 }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -381,7 +381,7 @@ impl Core {
         let reader = Reader::new_from(reader);
 
         // A RecordReader is created from the Reader to read transactions.
-        let mut tx_reader = RecordReader::new(reader);
+        let mut tx_reader = RecordReader::new(reader, opts.clone());
 
         // A Record is created to hold the transactions. The maximum number of entries per transaction is specified.
         let mut tx = Record::new();
@@ -427,7 +427,12 @@ impl Core {
                 "Repairing corrupted segment with id: {} and offset: {}",
                 corrupted_segment_id, corrupted_offset
             );
-            repair_last_corrupted_segment(clog, corrupted_segment_id, corrupted_offset)?;
+            repair_last_corrupted_segment(
+                clog,
+                opts.clone(),
+                corrupted_segment_id,
+                corrupted_offset,
+            )?;
         }
 
         Ok(num_entries)

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -2598,7 +2598,8 @@ mod tests {
         let sr = SegmentRef::read_segments_from_directory(clog_subdir.as_path()).unwrap();
         let reader = MultiSegmentReader::new(sr).unwrap();
         let reader = Reader::new_from(reader);
-        let mut tx_reader = RecordReader::new(reader);
+        let mut tx_reader =
+            RecordReader::new(reader, store.inner.as_ref().unwrap().core.opts.clone());
 
         // Expect ("k2", "v2")
         let mut log_rec = Record::new();


### PR DESCRIPTION
## Description

This change introduces a new option to skip the checksum calculation during restart. By default, the checksum for a record is calculated based on all fields in the record, including key/value bytes. This ensures data integrity, but when dealing with large key/value sizes, calculating the checksum can be time-consuming and significantly slow down restart times.

With this new option, users can choose to skip the checksum calculation during restart, which can lead to faster restarts, particularly in scenarios where large records are involved. However, it is important to note that skipping the checksum calculation may have implications for data integrity during the restart process. Specifically, if any corruption or discrepancies exist in the record data, they may not be detected if the checksum is skipped. Therefore, this option should be used with caution and primarily in scenarios where performance is prioritized over strict data consistency checks at restart.