### PR TITLE
chore: handle close when runtime is dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin' ]
+        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin', 'wasm32-unknown-unknown' ]
     steps:
       - uses: actions/checkout@v2
       - name: Cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,8 +502,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1221,6 +1223,7 @@ dependencies = [
  "fastrand",
  "fmmap",
  "futures",
+ "getrandom",
  "libc",
  "lru",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lru = "0.12.0"
 async-channel = "2.3.1"
 futures = "0.3.30"
 bytes = "1.5.0"
-tokio = { version = "1.36", features = ["rt", "sync"] }
+tokio = { version = "1.36", features = ["rt", "sync", "rt-multi-thread"] }
 quick_cache = "0.6.0"
 vart = "0.7.0"
 revision = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ lru = "0.12.0"
 async-channel = "2.3.1"
 futures = "0.3.30"
 bytes = "1.5.0"
-tokio = { version = "1.36", features = ["rt", "sync", "rt-multi-thread"] }
+tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
 vart = "0.7.0"
 revision = "0.10.0"
+getrandom = { version = "0.2.15", features = ["js"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
 vart = "0.7.0"
 revision = "0.10.0"
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
 
 [dev-dependencies]

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -181,27 +181,16 @@ impl Store {
 impl Drop for Store {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take() {
-            // Try to get existing runtime handle first
-            if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                // We're in a runtime, spawn normally
-                handle.spawn(async move {
-                    if let Err(err) = inner.close().await {
-                        // TODO: use log/tracing instead of eprintln
-                        eprintln!("Error closing store: {}", err);
-                    }
-                });
-            } else {
-                // No runtime, create a temporary one
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    // Block until close completes
-                    if let Err(err) = rt.block_on(inner.close()) {
-                        // TODO: use log/tracing instead of eprintln
-                        eprintln!("Error closing store: {}", err);
-                    }
-                } else {
+            // Always create a new runtime for cleanup
+            if let Ok(rt) = tokio::runtime::Runtime::new() {
+                // Block until close completes
+                if let Err(err) = rt.block_on(inner.close()) {
                     // TODO: use log/tracing instead of eprintln
-                    eprintln!("Failed to create runtime for store cleanup");
+                    eprintln!("Error closing store: {}", err);
                 }
+            } else {
+                // TODO: use log/tracing instead of eprintln
+                eprintln!("Failed to create runtime for store cleanup");
             }
         }
     }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -191,19 +191,7 @@ impl Drop for Store {
                     }
                 });
             } else {
-                // No runtime, create a temporary one
-                if let Ok(rt) = tokio::runtime::Runtime::new() {
-                    // Block until close completes
-                    rt.spawn(async move {
-                        if let Err(err) = inner.close().await {
-                            // TODO: use log/tracing instead of eprintln
-                            eprintln!("Error closing store: {}", err);
-                        }
-                    });
-                } else {
-                    // TODO: use log/tracing instead of eprintln
-                    eprintln!("Failed to create runtime for store cleanup");
-                }
+                eprintln!("No runtime available for closing the store correctly");
             }
         }
     }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -199,7 +199,7 @@ impl Drop for Store {
                             // TODO: use log/tracing instead of eprintln
                             eprintln!("Error closing store: {}", err);
                         }
-                    });    
+                    });
                 } else {
                     // TODO: use log/tracing instead of eprintln
                     eprintln!("Failed to create runtime for store cleanup");

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -181,13 +181,28 @@ impl Store {
 impl Drop for Store {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take() {
-            // Close the store asynchronously
-            tokio::spawn(async move {
-                if let Err(err) = inner.close().await {
+            // Try to get existing runtime handle first
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                // We're in a runtime, spawn normally
+                handle.spawn(async move {
+                    if let Err(err) = inner.close().await {
+                        // TODO: use log/tracing instead of eprintln
+                        eprintln!("Error closing store: {}", err);
+                    }
+                });
+            } else {
+                // No runtime, create a temporary one
+                if let Ok(rt) = tokio::runtime::Runtime::new() {
+                    // Block until close completes
+                    if let Err(err) = rt.block_on(inner.close()) {
+                        // TODO: use log/tracing instead of eprintln
+                        eprintln!("Error closing store: {}", err);
+                    }
+                } else {
                     // TODO: use log/tracing instead of eprintln
-                    eprintln!("Error occurred while closing the kv store: {}", err);
+                    eprintln!("Failed to create runtime for store cleanup");
                 }
-            });
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Previously, when a Store was dropped without being explicitly closed (especially during program shutdown),
it could fail with "no reactor running" errors. This change gracefully falls back to creating a temporary runtime if necessary
