### PR TITLE
Do not hold write lock while updating the index

### DIFF
--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -7,6 +7,7 @@ use crate::storage::kv::store::Core;
 
 /// The `Indexer` struct is responsible for managing the index of key-value pairs.
 /// It uses a `vart` index, which is a type of persistent, lock-free B+ tree.
+#[derive(Clone)]
 pub(crate) struct Indexer {
     pub(crate) index: VartIndex<VariableSizeKey, IndexValue>,
 }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -652,13 +652,13 @@ impl Core {
     where
         F: Fn(&Entry) -> IndexValue,
     {
-        let mut index = self.indexer.write();
+        let mut new_index = self.indexer.read().clone();
 
         for entry in &task.entries {
             // If the entry is marked as deleted, delete it.
             if let Some(metadata) = entry.metadata.as_ref() {
                 if metadata.is_deleted() {
-                    index.delete(&mut entry.key[..].into());
+                    new_index.delete(&mut entry.key[..].into());
                     continue;
                 }
             }
@@ -666,7 +666,7 @@ impl Core {
             let index_value = encode_entry(entry);
 
             if self.opts.enable_versions {
-                index.insert(
+                new_index.insert(
                     &mut entry.key[..].into(),
                     index_value,
                     task.tx_id,
@@ -674,7 +674,7 @@ impl Core {
                     true,
                 )?;
             } else {
-                index.insert_or_replace(
+                new_index.insert_or_replace(
                     &mut entry.key[..].into(),
                     index_value,
                     task.tx_id,
@@ -683,6 +683,8 @@ impl Core {
                 )?;
             }
         }
+
+        *self.indexer.write() = new_index;
 
         Ok(())
     }


### PR DESCRIPTION
Since all writes are already serialized via the oracle and the task channel, there's actually no need to hold the index write lock while updating it because there can be no other concurrent transactions updating the index at the same time.
It's sufficient to clone it using the cheaper read lock, make all the modifications, and then update it as a whole at once. This is sorta RCU thanks to the copy-on-write vart tree. This should help parallel readers to experience less contention when starting transactions.

As a follow-up, we could probably take it even further by getting rid of the RWLock completely and use atomic pointer swap instead, for example the `arc-swap` crate.

Tested with SurrealDB.