### PR TITLE
fix: do not allow blind writes in SI

### DIFF
--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -1054,7 +1054,9 @@ mod tests {
                 Err(err) => {
                     matches!(err, Error::TransactionReadConflict)
                 }
-                _ => false,
+                _ => {
+                    false
+                }
             });
         }
 
@@ -1257,7 +1259,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn mvcc_serialized_snapshot_isolation_scan() {
         mvcc_with_scan_tests(true).await;
     }


### PR DESCRIPTION
## Description

Snapshot isolation forbids write-write conflict. This PR fixes it as current SI allows blind writes