### PR TITLE
Add Transaction::insert_or_replace()

### DIFF
--- a/src/storage/kv/entry.rs
+++ b/src/storage/kv/entry.rs
@@ -15,6 +15,7 @@ pub(crate) struct Entry {
     pub(crate) metadata: Option<Metadata>,
     pub(crate) value: Bytes,
     pub(crate) ts: u64,
+    pub(crate) replace: bool,
 }
 
 impl Entry {
@@ -24,6 +25,7 @@ impl Entry {
             metadata: None,
             value: Bytes::copy_from_slice(value),
             ts: 0,
+            replace: false,
         }
     }
 
@@ -33,6 +35,10 @@ impl Entry {
 
     pub(crate) fn set_ts(&mut self, ts: u64) {
         self.ts = ts;
+    }
+
+    pub(crate) fn set_replace(&mut self, replace: bool) {
+        self.replace = replace;
     }
 
     pub(crate) fn mark_delete(&mut self) {

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -224,7 +224,17 @@ impl Transaction {
 
     /// Adds a key-value pair to the store.
     pub fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        let entry = Entry::new(key, value);
+        let mut entry = Entry::new(key, value);
+        // Replace when versions are disabled.
+        entry.set_replace(!self.core.opts.enable_versions);
+        self.write(entry)?;
+        Ok(())
+    }
+
+    /// Inserts if not present or replaces an existing key-value pair.
+    pub fn insert_or_replace(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        let mut entry = Entry::new(key, value);
+        entry.set_replace(true);
         self.write(entry)?;
         Ok(())
     }
@@ -233,6 +243,8 @@ impl Transaction {
     pub fn set_at_ts(&mut self, key: &[u8], value: &[u8], ts: u64) -> Result<()> {
         let mut entry = Entry::new(key, value);
         entry.set_ts(ts);
+        // Replace when versions are disabled.
+        entry.set_replace(!self.core.opts.enable_versions);
         self.write(entry)?;
         Ok(())
     }
@@ -254,6 +266,8 @@ impl Transaction {
         let value = Bytes::new();
         let mut entry = Entry::new(key, &value);
         entry.mark_tombstone();
+        // Replace when versions are disabled.
+        entry.set_replace(!self.core.opts.enable_versions);
         self.write(entry)?;
         Ok(())
     }


### PR DESCRIPTION
Needed in SurrealDB to prevent generating unnecessary version for periodic bookkeeping tasks
https://github.com/surrealdb/surrealdb/pull/5147 