### PR TITLE
Fix: Wasm spawn 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,3 @@ jobs:
 
       - name: Format
         run: cargo fmt --all -- --check
-
-  semver:
-    name: semver
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -10,6 +10,14 @@ defaults:
     shell: bash
 
 jobs:
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   publish-crate:
     name: Publish crate
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  semver:
+    name: semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+
   release:
     name: Process Release
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1239,6 +1239,7 @@ dependencies = [
  "tokio",
  "vart 0.7.0",
  "walkdir",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1365,6 +1366,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
@@ -30,6 +30,7 @@ vart = "0.7.0"
 revision = "0.10.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
+wasm-bindgen-futures = "0.4.45"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -48,8 +49,4 @@ walkdir = "2.5.0"
 
 [[bench]]
 name = "store_bench"
-harness = false
-
-[[bench]]
-name = "load_bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.5.5"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -243,9 +243,9 @@ fn concurrent_insert(c: &mut Criterion) {
     // Configuration
     let item_count = 100_000;
 
-    let key_sizes = vec![16]; // in bytes
-    let value_sizes = vec![32]; // in bytes
-    let thread_counts = vec![4];
+    let key_sizes = vec![16, 64, 256, 1024]; // in bytes
+    let value_sizes = vec![32, 128, 512, 2048]; // in bytes
+    let thread_counts = vec![1, 2, 4, num_cpus::get()];
 
     let mut group = c.benchmark_group("concurrent_inserts");
     group.throughput(criterion::Throughput::Elements(item_count as u64));
@@ -396,7 +396,7 @@ fn concurrent_workload(c: &mut Criterion) {
 
     let operations_per_thread = 1000;
     let value_size = 1000;
-    let thread_counts = [4];
+    let thread_counts = [2, 4, num_cpus::get() as u64];
     let read_ratios = [0.0, 0.5, 0.95, 1.0]; // 0%, 50%, 95%, 100% reads
 
     for &thread_count in &thread_counts {
@@ -481,4 +481,4 @@ criterion_group!(
 );
 criterion_group!(benches_range, range_scan);
 criterion_group!(benches_concurrent, concurrent_insert, concurrent_workload);
-criterion_main!(benches_concurrent);
+criterion_main!(benches_insert, benches_range);

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -243,9 +243,9 @@ fn concurrent_insert(c: &mut Criterion) {
     // Configuration
     let item_count = 100_000;
 
-    let key_sizes = vec![16, 64, 256, 1024]; // in bytes
-    let value_sizes = vec![32, 128, 512, 2048]; // in bytes
-    let thread_counts = vec![1, 2, 4, num_cpus::get()];
+    let key_sizes = vec![16]; // in bytes
+    let value_sizes = vec![32]; // in bytes
+    let thread_counts = vec![4];
 
     let mut group = c.benchmark_group("concurrent_inserts");
     group.throughput(criterion::Throughput::Elements(item_count as u64));
@@ -396,7 +396,7 @@ fn concurrent_workload(c: &mut Criterion) {
 
     let operations_per_thread = 1000;
     let value_size = 1000;
-    let thread_counts = [2, 4, num_cpus::get() as u64];
+    let thread_counts = [4];
     let read_ratios = [0.0, 0.5, 0.95, 1.0]; // 0%, 50%, 95%, 100% reads
 
     for &thread_count in &thread_counts {
@@ -481,4 +481,4 @@ criterion_group!(
 );
 criterion_group!(benches_range, range_scan);
 criterion_group!(benches_concurrent, concurrent_insert, concurrent_workload);
-criterion_main!(benches_insert, benches_range);
+criterion_main!(benches_concurrent);

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -6,10 +6,6 @@ use std::vec;
 
 use async_channel::{bounded, Receiver, Sender};
 use futures::{select, FutureExt};
-use tokio::{
-    sync::Mutex as AsyncMutex,
-    task::{spawn, JoinHandle},
-};
 
 use ahash::{HashMap, HashMapExt};
 use bytes::{Bytes, BytesMut};
@@ -39,7 +35,7 @@ pub(crate) struct StoreInner {
     pub(crate) is_closed: AtomicBool,
     pub(crate) is_compacting: AtomicBool,
     stop_tx: Sender<()>,
-    task_runner_handle: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
+    done_rx: Receiver<()>,
     pub(crate) stats: Arc<StorageStats>,
 }
 
@@ -54,14 +50,15 @@ impl StoreInner {
         let (stop_tx, stop_rx) = bounded(1);
 
         let core = Arc::new(Core::new(opts, writes_tx)?);
-        let task_runner_handle = TaskRunner::new(core.clone(), writes_rx, stop_rx).spawn();
+        let (task_runner, done_rx) = TaskRunner::new(core.clone(), writes_rx, stop_rx);
+        task_runner.spawn();
 
         Ok(Self {
             core,
             stop_tx,
+            done_rx,
             is_closed: AtomicBool::new(false),
             is_compacting: AtomicBool::new(false),
-            task_runner_handle: Arc::new(AsyncMutex::new(Some(task_runner_handle))),
             stats: Arc::new(StorageStats::new()),
         })
     }
@@ -82,15 +79,10 @@ impl StoreInner {
             .await
             .map_err(|e| Error::SendError(format!("{}", e)))?;
 
-        // Wait for task to finish
-        if let Some(handle) = self.task_runner_handle.lock().await.take() {
-            handle.await.map_err(|e| {
-                Error::ReceiveError(format!(
-                    "Error occurred while closing the kv store. JoinError: {}",
-                    e
-                ))
-            })?;
-        }
+        // Wait for done signal
+        self.done_rx.recv().await.map_err(|e| {
+            Error::ReceiveError(format!("Error waiting for task runner to complete: {}", e))
+        })?;
 
         self.core.close()?;
 
@@ -201,36 +193,59 @@ pub(crate) struct TaskRunner {
     core: Arc<Core>,
     writes_rx: Receiver<Task>,
     stop_rx: Receiver<()>,
+    // Done channel to signal completion
+    done_tx: Arc<Sender<()>>,
 }
 
 impl TaskRunner {
-    fn new(core: Arc<Core>, writes_rx: Receiver<Task>, stop_rx: Receiver<()>) -> Self {
-        Self {
-            core,
-            writes_rx,
-            stop_rx,
-        }
+    fn new(
+        core: Arc<Core>,
+        writes_rx: Receiver<Task>,
+        stop_rx: Receiver<()>,
+    ) -> (Self, Receiver<()>) {
+        let (done_tx, done_rx) = bounded(1);
+        (
+            Self {
+                core,
+                writes_rx,
+                stop_rx,
+                done_tx: Arc::new(done_tx),
+            },
+            done_rx,
+        )
     }
 
-    fn spawn(self) -> JoinHandle<()> {
-        spawn(Box::pin(async move {
-            loop {
-                select! {
-                    req = self.writes_rx.recv().fuse() => {
-                        let task = req.unwrap();
-                        self.handle_task(task).await
-                    },
-                    _ = self.stop_rx.recv().fuse() => {
-                        // Consume all remaining items in writes_rx
-                        while let Ok(task) = self.writes_rx.try_recv() {
-                            self.handle_task(task).await;
-                        }
-                        drop(self);
-                        return;
-                    },
-                }
+    fn spawn(self) {
+        let done_tx = self.done_tx.clone();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::spawn(self.run(done_tx));
+
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(self.run(done_tx));
+    }
+
+    async fn run(self, done_tx: Arc<Sender<()>>) {
+        loop {
+            select! {
+                req = self.writes_rx.recv().fuse() => {
+                    match req {
+                        Ok(task) => self.handle_task(task).await,
+                        Err(_) => break,
+                    }
+                },
+                _ = self.stop_rx.recv().fuse() => {
+                    // Consume all remaining items in writes_rx
+                    while let Ok(task) = self.writes_rx.try_recv() {
+                        self.handle_task(task).await;
+                    }
+                    break;
+                },
             }
-        }))
+        }
+
+        // Signal completion
+        let _ = done_tx.send(()).await;
     }
 
     async fn handle_task(&self, task: Task) {
@@ -746,6 +761,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::storage::kv::option::Options;
+    use crate::storage::kv::store::Core;
     use crate::storage::kv::store::{Store, Task, TaskRunner};
     use crate::storage::kv::transaction::Durability;
     use crate::storage::log::Error as LogError;
@@ -928,59 +944,6 @@ mod tests {
             txn.set(key, &default_value).unwrap();
             txn.commit().await.unwrap();
         }
-    }
-
-    #[tokio::test]
-    async fn stop_task_runner() {
-        // Create a temporary directory for testing
-        let temp_dir = create_temp_directory();
-
-        // Create store options with the test directory
-        let mut opts = Options::new();
-        opts.dir = temp_dir.path().to_path_buf();
-
-        // Create a new store instance with VariableKey as the key type
-        let store = Store::new(opts).expect("should create store");
-
-        let (writes_tx, writes_rx) = bounded(100);
-        let (stop_tx, stop_rx) = bounded(1);
-        let core = &store.inner.as_ref().unwrap().core;
-
-        let runner = TaskRunner::new(core.clone(), writes_rx, stop_rx);
-        let fut = runner.spawn();
-
-        // Send some tasks
-        let task_counter = Arc::new(AtomicU64::new(0));
-        for i in 0..100 {
-            let (done_tx, done_rx) = bounded(1);
-            writes_tx
-                .send(Task {
-                    entries: vec![],
-                    done: Some(done_tx),
-                    tx_id: i,
-                    durability: Durability::default(),
-                })
-                .await
-                .unwrap();
-
-            let task_counter = Arc::clone(&task_counter);
-            tokio::spawn(async move {
-                done_rx.recv().await.unwrap().unwrap();
-                task_counter.fetch_add(1, Ordering::SeqCst);
-            });
-        }
-
-        // Send stop signal
-        stop_tx.send(()).await.unwrap();
-
-        // Wait for a while to let TaskRunner handle all tasks by waiting on done_rx
-        fut.await.expect("TaskRunner should finish");
-
-        // Wait for the spawned tokio thread to finish
-        tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-
-        // Check if all tasks were handled
-        assert_eq!(task_counter.load(Ordering::SeqCst), 100);
     }
 
     async fn concurrent_task(store: Arc<Store>) {
@@ -1839,5 +1802,111 @@ mod tests {
                 assert_eq!(val, default_value.as_ref());
             }
         }
+    }
+
+    #[tokio::test]
+    async fn stop_task_runner_with_pending_tasks() {
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
+
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
+
+        let (writes_tx, writes_rx) = bounded(100);
+        let (stop_tx, stop_rx) = bounded(1);
+        let core = Arc::new(Core::new(opts, writes_tx.clone()).unwrap());
+
+        let (runner, done_rx) = TaskRunner::new(core.clone(), writes_rx, stop_rx);
+        runner.spawn();
+
+        // Create a task that will take some time to process
+        let (slow_done_tx, slow_done_rx) = bounded(1);
+        let slow_task = Task {
+            entries: vec![],
+            done: Some(slow_done_tx),
+            tx_id: 1,
+            durability: Durability::default(),
+        };
+
+        // Send the slow task
+        writes_tx.send(slow_task).await.unwrap();
+
+        // Send stop signal immediately
+        stop_tx.send(()).await.unwrap();
+
+        // Wait for TaskRunner to finish
+        done_rx
+            .recv()
+            .await
+            .expect("TaskRunner should signal completion");
+
+        // Verify the slow task was completed
+        assert!(slow_done_rx.recv().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn stop_task_runner_concurrent_tasks() {
+        // Create a temporary directory for testing
+        let temp_dir = create_temp_directory();
+
+        // Create store options with the test directory
+        let mut opts = Options::new();
+        opts.dir = temp_dir.path().to_path_buf();
+
+        let (writes_tx, writes_rx) = bounded(100);
+        let (stop_tx, stop_rx) = bounded(1);
+        let core = Arc::new(Core::new(opts, writes_tx.clone()).unwrap());
+
+        let (runner, done_rx) = TaskRunner::new(core.clone(), writes_rx, stop_rx);
+        runner.spawn();
+
+        let task_counter = Arc::new(AtomicU64::new(0));
+        let total_tasks = 1000;
+
+        // Spawn a task that continuously sends tasks
+        let task_sender = {
+            let writes_tx = writes_tx.clone();
+            let task_counter = task_counter.clone();
+            tokio::spawn(async move {
+                for i in 0..total_tasks {
+                    let (done_tx, done_rx) = bounded(1);
+                    writes_tx
+                        .send(Task {
+                            entries: vec![],
+                            done: Some(done_tx),
+                            tx_id: i,
+                            durability: Durability::default(),
+                        })
+                        .await
+                        .unwrap();
+
+                    let task_counter = task_counter.clone();
+                    tokio::spawn(async move {
+                        done_rx.recv().await.unwrap().unwrap();
+                        task_counter.fetch_add(1, Ordering::SeqCst);
+                    });
+                }
+            })
+        };
+
+        // Wait a bit to let some tasks queue up
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Send stop signal
+        stop_tx.send(()).await.unwrap();
+
+        // Wait for TaskRunner to finish
+        done_rx
+            .recv()
+            .await
+            .expect("TaskRunner should signal completion");
+
+        // Wait for task sender to finish
+        task_sender.await.unwrap();
+
+        // Check that all tasks that were sent were processed
+        let final_count = task_counter.load(Ordering::SeqCst);
+        assert_eq!(final_count, total_tasks, "Should have processed all tasks");
     }
 }


### PR DESCRIPTION
## Description

Fixes the issue for wasm spawn. There is no dependency on JoinHandle so that the task runner can be spawned using tokio or wasm-bindgen