### PR TITLE
Make soft_delete completely remove values when replace is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ahash",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "surrealkv"
 publish = true
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This PR is a follow-up to https://github.com/surrealdb/surrealkv/pull/134.

When versions are disabled, `Transaction::soft_delete` should act as `Transaction::delete` and completely remove 
values from the index. Same should happen when loading up the index with versions disabled.