### PR TITLE
Use ahash::HashSet

### DIFF
--- a/src/storage/kv/compaction.rs
+++ b/src/storage/kv/compaction.rs
@@ -28,7 +28,7 @@ impl<'a> CompactionGuard<'a> {
     }
 }
 
-impl<'a> Drop for CompactionGuard<'a> {
+impl Drop for CompactionGuard<'_> {
     fn drop(&mut self) {
         self.is_compacting.store(false, Ordering::Relaxed);
     }

--- a/src/storage/kv/repair.rs
+++ b/src/storage/kv/repair.rs
@@ -25,7 +25,7 @@ pub fn repair_last_corrupted_segment(
     // Get the last segment
     let last_segment = segs
         .last()
-        .ok_or_else(|| Error::LogError(LogError::SegmentNotFound))?;
+        .ok_or(Error::LogError(LogError::SegmentNotFound))?;
 
     // Check if the last segment's ID is equal to the corrupted_segment_id
     if last_segment.id != corrupted_segment_id {

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
 use ahash::{HashMap, HashMapExt};
+use ahash::{HashSet, HashSetExt};
 use bytes::Bytes;
 use std::collections::hash_map::Entry as HashEntry;
 use vart::{art::QueryType, VariableSizeKey};
@@ -875,9 +875,8 @@ impl Transaction {
         }
 
         // Process the last key's versions.
-        if let Some(key) = current_key {
+        if current_key.is_some() {
             results.append(&mut current_key_versions);
-            unique_keys.insert(key);
         }
 
         // Return the results.


### PR DESCRIPTION
Just a small cleanup:
- Use `HashSet` with `ahash`.
- I don't think there's need to insert a key in the unique keys set when processing the last key's versions.
- Fixing clippy lints for Rust 1.83.0.