### PR TITLE
Feat/improve snapshot isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "async-channel"
@@ -174,9 +174,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cast"
@@ -186,9 +186,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.37"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "shlex",
 ]
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "colorchoice"
@@ -424,12 +424,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -621,9 +621,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -721,16 +721,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -742,9 +743,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"
@@ -790,7 +791,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -837,11 +838,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1014,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1210,9 +1210,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -1264,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -1319,9 +1319,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1441,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-width"
@@ -1528,9 +1528,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1554,21 +1554,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1576,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1589,15 +1590,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/storage/kv/error.rs
+++ b/src/storage/kv/error.rs
@@ -23,6 +23,7 @@ pub enum Error {
     KeyNotFound,                        // The key was not found
     CorruptedIndex,                     // The index is corrupted
     TransactionReadConflict,            // A read conflict occurred in the transaction
+    TransactionWriteConflict,           // A write conflict occurred in the transaction
     StoreClosed,                        // The store was closed
     InvalidAttributeData,               // The attribute data is invalid
     UnknownAttributeType,               // The attribute type is unknown
@@ -66,6 +67,7 @@ impl fmt::Display for Error {
             Error::KeyNotFound => write!(f, "Key not found"),
             Error::CorruptedIndex => write!(f, "Corrupted index"),
             Error::TransactionReadConflict => write!(f, "Transaction read conflict"),
+            Error::TransactionWriteConflict => write!(f, "Transaction write conflict"),
             Error::StoreClosed => write!(f, "Store closed"),
             Error::InvalidAttributeData => write!(f, "Invalid attribute data"),
             Error::UnknownAttributeType => write!(f, "Unknown attribute type"),

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -194,16 +194,8 @@ fn key_in_range(
 /// category of "serializable" isolation levels. It provides serializability while allowing for
 /// a higher degree of concurrency compared to traditional serializability mechanisms.
 ///
-/// SSI allows for "snapshot isolation" semantics, where a transaction sees a consistent snapshot of
-/// the database as of its start time. It uses timestamps to control the order in which transactions
-/// read and write data, preventing anomalies like write skew and lost updates.
-///
-/// This struct manages the coordination of read and write operations by maintaining timestamps
-/// for transactions and tracking committed transactions.
-///
-/// - `commit_tracker` maintains information about committed transactions and their timestamps.
-/// - `txn_mark` is a watermark used to block new transactions until previous commits are visible.
-/// - `read_mark` is another watermark that marks the visibility of read operations to other transactions.
+/// This implementation adopts Write Snapshot Isolation as defined in the paper:
+/// https://arxiv.org/abs/2405.18393
 pub(crate) struct SerializableSnapshotIsolation {
     next_tx_id: AtomicU64,
 }

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -1,17 +1,9 @@
 use std::{
-    cmp::Reverse,
-    collections::BinaryHeap,
-    ops::Bound,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    ops::{Bound, RangeBounds},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
-use ahash::{HashMap, HashMapExt, HashSet};
-use async_channel::{bounded, Receiver, Sender};
 use bytes::Bytes;
-use parking_lot::{Mutex, RwLock};
 use tokio::sync::Mutex as AsyncMutex;
 use vart::VariableSizeKey;
 
@@ -68,28 +60,6 @@ impl Oracle {
     pub(crate) fn set_ts(&self, ts: u64) {
         self.isolation.set_ts(ts);
         self.isolation.increment_ts();
-    }
-
-    /// Marks the transactions as committed up to the given timestamp.
-    /// If the isolation level is SerializableSnapshotIsolation, it delegates to the isolation level to mark the transactions.
-    pub(crate) fn committed_upto(&self, ts: u64) {
-        match &self.isolation {
-            IsolationLevel::SnapshotIsolation(_) => {}
-            IsolationLevel::SerializableSnapshotIsolation(oracle) => {
-                oracle.txn_mark.done_upto(ts);
-            }
-        }
-    }
-
-    /// Waits for the transactions to commit up to the given timestamp.
-    /// If the isolation level is SerializableSnapshotIsolation, it delegates to the isolation level to wait for the transactions.
-    pub(crate) fn wait_for(&self, ts: u64) {
-        match &self.isolation {
-            IsolationLevel::SnapshotIsolation(_) => {}
-            IsolationLevel::SerializableSnapshotIsolation(oracle) => {
-                oracle.txn_mark.wait_for(ts);
-            }
-        }
     }
 }
 
@@ -161,20 +131,21 @@ impl SnapshotIsolation {
     pub(crate) fn new_commit_ts(&self, txn: &mut Transaction) -> Result<u64> {
         let current_snapshot = Snapshot::take(&txn.core)?;
 
-        for entry in txn.read_set.iter() {
-            match current_snapshot.get(&entry.key[..].into()) {
-                Ok((_, version)) => {
-                    if entry.ts != version {
-                        return Err(Error::TransactionReadConflict);
+        // Check write conflicts
+        for key in txn.write_set.keys() {
+            if let Some(last_entry) = txn.write_set.get(key).and_then(|entries| entries.last()) {
+                match current_snapshot.get(&key[..].into()) {
+                    Ok((_, version)) => {
+                        // Detect if another transaction has written to this key
+                        if version > last_entry.version {
+                            return Err(Error::TransactionReadConflict);
+                        }
                     }
-                }
-                Err(Error::KeyNotFound) => {
-                    if entry.ts > 0 {
-                        return Err(Error::TransactionReadConflict);
+                    Err(Error::KeyNotFound) => {
+                        continue;
                     }
-                    continue;
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
             }
         }
 
@@ -194,93 +165,22 @@ impl SnapshotIsolation {
     }
 }
 
-/// Struct representing a commit marker in a transaction.
-/// It contains a timestamp and a set of conflict keys.
-struct CommitMarker {
-    ts: u64,
-    conflict_keys: HashSet<Bytes>,
-}
-
-/// Struct for tracking committed transactions.
-/// It maintains the next timestamp, a list of committed transactions, and the last cleanup timestamp.
-#[derive(Default)]
-struct CommitTracker {
-    next_ts: u64,
-    committed_transactions: Vec<CommitMarker>,
-    last_cleanup_ts: u64,
-}
-
-impl CommitTracker {
-    /// Creates a new CommitTracker instance with the next timestamp, committed transactions, and last cleanup timestamp set to 0.
-    fn new() -> Self {
-        Self {
-            next_ts: 0,
-            committed_transactions: Vec::new(),
-            last_cleanup_ts: 0,
-        }
-    }
-
-    /// Cleans up committed transactions with timestamps greater than the given maximum read timestamp.
-    /// It updates the last cleanup timestamp and removes committed transactions with timestamps greater than the maximum read timestamp.
-    fn cleanup_committed_transactions(&mut self, max_read_ts: u64) {
-        if max_read_ts <= self.last_cleanup_ts {
-            return;
-        }
-
-        self.last_cleanup_ts = max_read_ts;
-
-        self.committed_transactions
-            .retain(|txn| txn.ts > max_read_ts);
-    }
-
-    /// Checks if a transaction has conflicts with committed transactions.
-    /// It acquires a lock on the read set and checks if there are any conflict keys in the read set.
-    fn has_conflict(&self, txn: &Transaction) -> bool {
-        if txn.read_set.is_empty() {
-            false
-        } else {
-            // For each object in the changeset of the already committed transactions, check if it lies
-            // within the predicates of the current transaction.
-            for committed_tx in self.committed_transactions.iter() {
-                if committed_tx.ts > txn.read_ts {
-                    for conflict_key in committed_tx.conflict_keys.iter() {
-                        for rs_entry in txn.read_key_ranges.iter() {
-                            if key_in_range(conflict_key, &rs_entry.start, &rs_entry.end) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            self.committed_transactions
-                .iter()
-                .filter(|committed_txn| committed_txn.ts > txn.read_ts)
-                .any(|committed_txn| {
-                    txn.read_set
-                        .iter()
-                        .any(|read| committed_txn.conflict_keys.contains(&read.key))
-                })
-        }
-    }
-}
-
 fn key_in_range(
     key: &Bytes,
-    range_start: &Bound<VariableSizeKey>,
-    range_end: &Bound<VariableSizeKey>,
+    range_start: &Bound<&VariableSizeKey>,
+    range_end: &Bound<&VariableSizeKey>,
 ) -> bool {
     let key = VariableSizeKey::from_slice(key);
 
     let start_inclusive = match &range_start {
-        Bound::Included(start) => key >= *start,
-        Bound::Excluded(start) => key > *start,
+        Bound::Included(start) => key >= **start,
+        Bound::Excluded(start) => key > **start,
         Bound::Unbounded => true,
     };
 
     let end_exclusive = match &range_end {
-        Bound::Included(end) => key <= *end,
-        Bound::Excluded(end) => key < *end,
+        Bound::Included(end) => key <= **end,
+        Bound::Excluded(end) => key < **end,
         Bound::Unbounded => true,
     };
 
@@ -304,244 +204,115 @@ fn key_in_range(
 /// - `commit_tracker` maintains information about committed transactions and their timestamps.
 /// - `txn_mark` is a watermark used to block new transactions until previous commits are visible.
 /// - `read_mark` is another watermark that marks the visibility of read operations to other transactions.
-///
-/// The serializable snapshot isolation (SSI) algorithm implemented here is inspired from BadgerDB.
 pub(crate) struct SerializableSnapshotIsolation {
-    // The `commit_tracker` keeps track of committed transactions and their timestamps.
-    commit_tracker: Mutex<CommitTracker>,
-
-    // The `txn_mark` and `read_mark` are used to manage visibility of transactions.
-    // `txn_mark` blocks `new_transaction` to ensure previous commits are visible to new reads.
-    txn_mark: Arc<WaterMark>,
-    // `read_mark` marks the visibility of read operations to other transactions.
-    read_mark: Arc<RwLock<BinaryHeap<Reverse<u64>>>>,
+    next_tx_id: AtomicU64,
 }
 
 impl SerializableSnapshotIsolation {
-    // Create a new instance of `SerializableSnapshotIsolation`.
+    /// Creates a new SerializableSnapshotIsolation instance with the next transaction ID set to 0.
     pub(crate) fn new() -> Self {
         Self {
-            commit_tracker: Mutex::new(CommitTracker::new()),
-            // Create a watermark for transactions.
-            txn_mark: Arc::new(WaterMark::new()),
-            // Create a watermark for read operations.
-            read_mark: Arc::new(RwLock::new(BinaryHeap::new())),
+            next_tx_id: AtomicU64::new(0),
         }
     }
 
-    // Retrieve the read timestamp for a new read operation.
-    pub(crate) fn read_ts(&self) -> u64 {
-        let commit_tracker = self.commit_tracker.lock();
-        let read_ts = commit_tracker.next_ts - 1;
-
-        // Keep track of the read timestamp for active transactions.
-        self.read_mark.write().push(Reverse(read_ts));
-
-        // Wait for the current read timestamp to be visible to new transactions.
-        self.txn_mark.wait_for(read_ts);
-        read_ts
+    /// Sets the next transaction ID to the given timestamp.
+    pub(crate) fn set_ts(&self, ts: u64) {
+        self.next_tx_id.store(ts, Ordering::SeqCst);
     }
 
-    // Generate a new commit timestamp for a transaction.
+    /// Generates a new commit timestamp for the given transaction.
+    /// It performs optimistic concurrency control (OCC) by checking if the read keys in the transaction
+    /// are still valid in the latest snapshot, and if the timestamp of the read keys matches the timestamp
+    /// of the latest snapshot. If the timestamp does not match, then there is a conflict.
     pub(crate) fn new_commit_ts(&self, txn: &mut Transaction) -> Result<u64> {
-        let mut commit_tracker = self.commit_tracker.lock();
+        let current_snapshot = Snapshot::take(&txn.core)?;
 
-        // Check for conflicts between the transaction and committed transactions.
-        if commit_tracker.has_conflict(txn) {
-            return Err(Error::TransactionReadConflict);
+        // Check read conflicts
+        for entry in txn.read_set.iter() {
+            match current_snapshot.get(&entry.key[..].into()) {
+                Ok((_, version)) => {
+                    if entry.ts != version {
+                        return Err(Error::TransactionReadConflict);
+                    }
+                }
+                Err(Error::KeyNotFound) => {
+                    if entry.ts > 0 {
+                        return Err(Error::TransactionReadConflict);
+                    }
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
         }
 
-        // Mark that read operations are done up to the transaction's read timestamp.
-        self.mark_read_operations_done(txn.read_ts);
+        // Check write conflicts
+        for key in txn.write_set.keys() {
+            if let Some(last_entry) = txn.write_set.get(key).and_then(|entries| entries.last()) {
+                match current_snapshot.get(&key[..].into()) {
+                    Ok((_, version)) => {
+                        // Detect if another transaction has written to this key
+                        if version > last_entry.version {
+                            return Err(Error::TransactionReadConflict);
+                        }
+                    }
+                    Err(Error::KeyNotFound) => {
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
 
-        // Clean up committed transactions up to the current read mark.
-        let max_read_ts = self.read_mark.read().peek().map_or(0, |peek| peek.0);
-        commit_tracker.cleanup_committed_transactions(max_read_ts);
+        // For each range, check if any write skew (including deletes) conflicts
+        for range in &txn.read_key_ranges {
+            // Get all writes in the range from the snapshot
+            let range_writes = current_snapshot.range(range.range.clone());
 
-        let ts = commit_tracker.next_ts;
-        commit_tracker.next_ts += 1;
+            for (key, _, version, _) in range_writes {
+                if *version > txn.read_ts {
+                    // Check if this key was deleted in current transaction
+                    match txn.write_set.get(&key[..]) {
+                        Some(entries)
+                            if entries
+                                .last()
+                                .map_or(false, |e| e.e.is_deleted_or_tombstone()) =>
+                        {
+                            // Key is being deleted in current txn, don't count as conflict
+                            continue;
+                        }
+                        _ => return Err(Error::TransactionReadConflict),
+                    }
+                }
+            }
 
-        assert!(ts >= commit_tracker.last_cleanup_ts);
+            // Check for deletes in current transaction that affect this range
+            for (key, entries) in &txn.write_set {
+                if key_in_range(key, &range.range.start_bound(), &range.range.end_bound()) {
+                    if let Some(entry) = entries.last() {
+                        let key = VariableSizeKey::from_slice(key);
+                        let res = current_snapshot.get(&key);
+                        if entry.e.is_deleted_or_tombstone() && res.is_err() {
+                            // This is a delete of a key that didn't exist at snapshot time
+                            return Err(Error::TransactionReadConflict);
+                        }
+                    }
+                }
+            }
+        }
 
-        // Add the transaction to the list of committed transactions with conflict keys.
-        let conflict_keys: HashSet<Bytes> = txn
-            .write_set
-            .values()
-            .filter_map(|entries| entries.last().map(|entry| entry.e.key.clone()))
-            .collect();
-
-        commit_tracker
-            .committed_transactions
-            .push(CommitMarker { ts, conflict_keys });
-
+        let ts = self.next_tx_id.load(Ordering::SeqCst);
+        self.increment_ts();
         Ok(ts)
     }
 
-    // Helper method to mark read operations as done up to a given timestamp.
-    fn mark_read_operations_done(&self, read_ts: u64) {
-        self.read_mark
-            .write()
-            .retain(|&read_timestamp| read_timestamp.0 > read_ts);
+    /// Returns the read timestamp, which is the next transaction ID minus 1.
+    pub(crate) fn read_ts(&self) -> u64 {
+        self.next_tx_id.load(Ordering::SeqCst) - 1
     }
 
-    // Set the global timestamp for the system.
-    pub(crate) fn set_ts(&self, ts: u64) {
-        self.commit_tracker.lock().next_ts = ts;
-
-        // Mark that read operations are done up to the given timestamp.
-        self.txn_mark.done_upto(ts);
-
-        // Mark that reads are done up to the given timestamp.
-        self.read_mark.write().retain(|&read_ts| read_ts.0 > ts);
-    }
-
-    // Increment the global timestamp for the system.
+    /// Increments the next transaction ID by 1.
     pub(crate) fn increment_ts(&self) {
-        let mut commit_info = self.commit_tracker.lock();
-        commit_info.next_ts += 1;
-    }
-}
-
-/// `WaterMark` is a synchronization mechanism for managing transaction timestamps.
-struct WaterMark {
-    mark: RwLock<WaterMarkState>, // Keeps track of waiters for specific timestamps.
-}
-
-struct WaterMarkState {
-    done_upto: u64,
-    waiters: HashMap<u64, Arc<Mark>>,
-}
-
-impl WaterMarkState {
-    fn new() -> Self {
-        Self {
-            done_upto: 0,
-            waiters: HashMap::new(),
-        }
-    }
-}
-
-/// Represents a waiter for a specific timestamp.
-struct Mark {
-    ch: Mutex<Option<Sender<()>>>, // Sender for notifying the waiter.
-    closer: Receiver<()>,          // Receiver for detecting closure.
-}
-
-impl Mark {
-    fn new() -> Arc<Self> {
-        let (tx, rx) = bounded(1);
-        Arc::new(Self {
-            ch: Mutex::new(Some(tx)),
-            closer: rx,
-        })
-    }
-
-    fn take(&self) -> Sender<()> {
-        self.ch.lock().take().unwrap()
-    }
-}
-
-impl WaterMark {
-    /// Creates a new `WaterMark` with the given initial done timestamp.
-    fn new() -> Self {
-        WaterMark {
-            mark: RwLock::new(WaterMarkState::new()),
-        }
-    }
-
-    /// Marks transactions as done up to the specified timestamp.
-    fn done_upto(&self, t: u64) {
-        let mut mark = self.mark.write();
-
-        let done_upto = mark.done_upto;
-        if done_upto >= t {
-            return;
-        }
-
-        for i in (done_upto + 1)..=t {
-            if let Some(wp) = mark.waiters.get(&i) {
-                wp.take();
-                mark.waiters.remove(&i);
-            }
-        }
-
-        mark.done_upto = t;
-    }
-
-    /// Waits for transactions to be done up to the specified timestamp.
-    fn wait_for(&self, t: u64) {
-        let mark = self.mark.read();
-        if mark.done_upto >= t {
-            return;
-        }
-        let should_insert = !mark.waiters.contains_key(&t);
-        drop(mark);
-
-        if should_insert {
-            let mut mark = self.mark.write();
-            mark.waiters.entry(t).or_insert_with(Mark::new);
-            drop(mark);
-        }
-
-        let mark = self.mark.read(); // Re-acquire the read lock.
-        let wp = mark.waiters.get(&t).cloned();
-        drop(mark);
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            use futures::executor::block_on;
-            if let Some(wp) = wp {
-                matches!(block_on(wp.closer.recv()), Err(async_channel::RecvError));
-            }
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            if let Some(wp) = wp {
-                matches!(wp.closer.recv_blocking(), Err(async_channel::RecvError));
-            }
-        }
-    }
-
-    /// Gets the highest completed timestamp.
-    fn _done_until(&self) -> u64 {
-        let mark = self.mark.read();
-        mark.done_upto
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-    use std::thread;
-
-    #[test]
-    fn waiters_new() {
-        let hub = WaterMark::new();
-
-        hub.done_upto(10);
-        let t2 = hub._done_until();
-        assert_eq!(t2, 10);
-
-        for i in 1..=10 {
-            hub.wait_for(i);
-        }
-    }
-
-    #[test]
-    fn waiters_async() {
-        let hub = Arc::new(WaterMark::new());
-        let hub_clone = Arc::clone(&hub);
-
-        // Spawn a thread to complete timestamp 1.
-        thread::spawn(move || {
-            // Wait for a while and then complete timestamp 1.
-            thread::sleep(std::time::Duration::from_millis(10));
-            hub_clone.done_upto(10);
-        });
-
-        // Now, wait for timestamp 1 in the main thread.
-        hub.wait_for(10);
+        self.next_tx_id.fetch_add(1, Ordering::SeqCst);
     }
 }

--- a/src/storage/kv/oracle.rs
+++ b/src/storage/kv/oracle.rs
@@ -138,7 +138,7 @@ impl SnapshotIsolation {
                     Ok((_, version)) => {
                         // Detect if another transaction has written to this key
                         if version > last_entry.version {
-                            return Err(Error::TransactionReadConflict);
+                            return Err(Error::TransactionWriteConflict);
                         }
                     }
                     Err(Error::KeyNotFound) => {
@@ -253,7 +253,7 @@ impl SerializableSnapshotIsolation {
                     Ok((_, version)) => {
                         // Detect if another transaction has written to this key
                         if version > last_entry.version {
-                            return Err(Error::TransactionReadConflict);
+                            return Err(Error::TransactionWriteConflict);
                         }
                     }
                     Err(Error::KeyNotFound) => {
@@ -294,7 +294,7 @@ impl SerializableSnapshotIsolation {
                         let res = current_snapshot.get(&key);
                         if entry.e.is_deleted_or_tombstone() && res.is_err() {
                             // This is a delete of a key that didn't exist at snapshot time
-                            return Err(Error::TransactionReadConflict);
+                            return Err(Error::TransactionWriteConflict);
                         }
                     }
                 }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -759,7 +759,7 @@ mod tests {
     use crate::storage::kv::store::{Store, Task, TaskRunner};
     use crate::storage::kv::transaction::Durability;
     use crate::storage::log::Error as LogError;
-    use crate::Error;
+    use crate::{Error, IsolationLevel};
 
     use async_channel::bounded;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1639,10 +1639,13 @@ mod tests {
     }
 
     // Common setup logic for creating a store
-    fn create_store(dir: Option<TempDir>) -> (Store, TempDir) {
+    fn create_store(dir: Option<TempDir>, is_ssi: bool) -> (Store, TempDir) {
         let temp_dir = dir.unwrap_or_else(create_temp_directory);
         let mut opts = Options::new();
         opts.dir = temp_dir.path().to_path_buf();
+        if is_ssi {
+            opts.isolation_level = IsolationLevel::SerializableSnapshotIsolation;
+        }
         (
             Store::new(opts.clone()).expect("should create store"),
             temp_dir,
@@ -1651,7 +1654,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_store_version_after_reopen() {
-        let (store, temp_dir) = create_store(None);
+        let (store, temp_dir) = create_store(None, false);
 
         // Define the number of keys, key size, and value size
         let num_keys = 10000u32;
@@ -1682,7 +1685,7 @@ mod tests {
         store.close().await.unwrap();
 
         // Reopen the store
-        let (store, _) = create_store(Some(temp_dir));
+        let (store, _) = create_store(Some(temp_dir), false);
 
         // Verify if the indexer version is set correctly
         assert_eq!(
@@ -1703,7 +1706,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_incremental_transaction_ids_post_store_open() {
-        let (store, temp_dir) = create_store(None);
+        let (store, temp_dir) = create_store(None, false);
 
         let total_records = 1000;
         let multiple_keys_records = total_records / 2;
@@ -1744,7 +1747,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         // Reopen the store
-        let (store, _) = create_store(Some(temp_dir));
+        let (store, _) = create_store(Some(temp_dir), false);
 
         // Commit a new transaction with a single key
         {
@@ -1900,7 +1903,7 @@ mod tests {
         assert!(slow_done_rx.recv().await.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn stop_task_runner_concurrent_tasks() {
         // Create a temporary directory for testing
         let temp_dir = create_temp_directory();
@@ -1964,5 +1967,101 @@ mod tests {
             "Expected {} tasks to be processed, but got {}",
             total_tasks, final_count
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_incremental_transaction_ids_concurrent() {
+        for is_ssi in [false, true] {
+            let (store, temp_dir) = create_store(None, is_ssi);
+            let store = Arc::new(store);
+
+            let total_records = 1000;
+            let multiple_keys_records = total_records / 2;
+
+            // Define keys and values
+            let keys: Vec<Bytes> = (1..=total_records)
+                .map(|i| Bytes::from(format!("key{}", i)))
+                .collect();
+            let values: Vec<Bytes> = (1..=total_records)
+                .map(|i| Bytes::from(format!("value{}", i)))
+                .collect();
+
+            // Insert multiple transactions with single keys concurrently
+            let mut tasks = Vec::new();
+            for (i, key) in keys.iter().enumerate().take(multiple_keys_records) {
+                let store = store.clone();
+                let key = key.clone();
+                let value = values[i].clone();
+                tasks.push(tokio::spawn(async move {
+                    let mut txn = store.begin().unwrap();
+                    txn.set(&key, &value).unwrap();
+                    txn.commit().await.unwrap();
+                }));
+            }
+
+            // Wait for all tasks to complete
+            for task in tasks {
+                task.await.unwrap();
+            }
+
+            // Insert multiple transactions with multiple keys concurrently
+            let mut tasks = Vec::new();
+            for (i, key) in keys
+                .iter()
+                .enumerate()
+                .skip(multiple_keys_records)
+                .take(multiple_keys_records)
+            {
+                let store = store.clone();
+                let key = key.clone();
+                let value = values[i].clone();
+                let next_key = keys[(i + multiple_keys_records) % keys.len()].clone();
+                let next_value = values[(i + multiple_keys_records) % values.len()].clone();
+                tasks.push(tokio::spawn(async move {
+                    let mut txn = store.begin().unwrap();
+                    txn.set(&key, &value).unwrap();
+                    txn.set(&next_key, &next_value).unwrap();
+                    txn.commit().await.unwrap();
+                }));
+            }
+
+            // Wait for all tasks to complete
+            for task in tasks {
+                task.await.unwrap();
+            }
+            // Close the store
+            store.close().await.unwrap();
+
+            // Add delay to ensure that the store is closed
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+            // Reopen the store
+            let (store, _) = create_store(Some(temp_dir), is_ssi);
+
+            // Commit a new transaction with a single key
+            {
+                let mut txn = store.begin().unwrap();
+                txn.set(&keys[0], &values[0]).unwrap();
+                txn.commit().await.unwrap();
+
+                let res = txn.get_versionstamp().unwrap();
+
+                assert_eq!(res.0, total_records as u64 + 1);
+            }
+
+            // Commit another new transaction with multiple keys
+            {
+                let mut txn = store.begin().unwrap();
+                txn.set(&keys[1], &values[1]).unwrap();
+                txn.set(&keys[2], &values[2]).unwrap();
+                txn.commit().await.unwrap();
+
+                let res = txn.get_versionstamp().unwrap();
+
+                assert_eq!(res.0, total_records as u64 + 2);
+            }
+
+            store.close().await.unwrap();
+        }
     }
 }

--- a/src/storage/kv/store.rs
+++ b/src/storage/kv/store.rs
@@ -570,11 +570,6 @@ impl Core {
             return Ok(());
         }
 
-        // Wait for the oracle to catch up to the latest commit transaction.
-        let oracle = self.oracle.clone();
-        let last_commit_ts = oracle.read_ts();
-        oracle.wait_for(last_commit_ts);
-
         // Close the commit log if it exists
         if let Some(clog) = &self.clog {
             clog.write().close()?;

--- a/src/storage/kv/transaction.rs
+++ b/src/storage/kv/transaction.rs
@@ -493,16 +493,11 @@ impl Transaction {
         let done = self
             .core
             .send_to_write_channel(entries, tx_id, self.durability)
-            .await;
-
-        if let Err(err) = done {
-            return Err(err);
-        }
+            .await?;
 
         drop(write_ch_lock);
 
         // Check if the transaction is written to the transaction log.
-        let done = done.unwrap();
         let ret = done.recv().await;
         if let Err(err) = ret {
             return Err(err.into());


### PR DESCRIPTION
This PR makes changes to the Snapshot Isolation implementation (both SI and SSI). It keeps SI similar to the definition in [paper](https://arxiv.org/abs/2405.18393) and rewrites SSI (by removing previous implementation as current way of transaction check is already serializable)