### PR TITLE
Make snapshot fully responsible for the visibility of keys

### DIFF
--- a/src/storage/kv/indexer.rs
+++ b/src/storage/kv/indexer.rs
@@ -123,6 +123,11 @@ impl IndexValue {
         }
     }
 
+    pub(crate) fn deleted(&self) -> bool {
+        self.metadata()
+            .is_some_and(|md| md.is_deleted_or_tombstone())
+    }
+
     pub(crate) fn segment_id(&self) -> u64 {
         match self {
             Self::Disk(e) => e.segment_id,


### PR DESCRIPTION
- Make snapshot's get and scan methods responsible for hiding the deleted keys.
- Remove the filters and their associated logic. We might bring them back in the future if we ever have more complicated conditions.
- Simplify some of the snapshot methods to use `Option` instead of `Result`, because not finding a key is not a failure.

Tested with SurrealDB.