### PR TITLE
fix: filter out deleted keys when searching at ts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "vart"
 version = "0.8.1"
-source = "git+https://github.com/surrealdb/vart?branch=refactor-scan-iters#e7890e09d1945befa6a0b3d5a0b133cf25660031"
+source = "git+https://github.com/surrealdb/vart?branch=refactor-scan-iters#88d291ecf3bad730841dc02a4f95fcfc9c209ccf"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,8 +1474,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "vart"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
+source = "git+https://github.com/surrealdb/vart?branch=refactor-scan-iters#e7890e09d1945befa6a0b3d5a0b133cf25660031"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "vart"
 version = "0.8.1"
-source = "git+https://github.com/surrealdb/vart?branch=refactor-scan-iters#88d291ecf3bad730841dc02a4f95fcfc9c209ccf"
+source = "git+https://github.com/surrealdb/vart?branch=main#6243aa8c82c8a8dc23c15cec1bedd5e5a52d8897"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = "0.8.1"
+vart = {git = "https://github.com/surrealdb/vart", branch = "refactor-scan-iters"}
 revision = "0.10.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.30"
 bytes = "1.5.0"
 tokio = { version = "1.36", features = ["rt", "sync"] }
 quick_cache = "0.6.0"
-vart = {git = "https://github.com/surrealdb/vart", branch = "refactor-scan-iters"}
+vart = {git = "https://github.com/surrealdb/vart", branch = "main"}
 revision = "0.10.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -107,7 +107,7 @@ impl StoreInner {
                                ts: u64,
                                metadata: Option<Metadata>|
          -> Result<()> {
-            let mut entry = Entry::new(&key, &value);
+            let mut entry = Entry::new(key, &value);
             entry.set_ts(ts);
 
             if let Some(md) = metadata {
@@ -146,7 +146,7 @@ impl StoreInner {
             let metadata = value.metadata();
 
             // If we've moved to a new key, decide whether to write the previous key's entries
-            if Some(&key.as_ref()) != current_key.as_ref() {
+            if Some(&key) != current_key.as_ref() {
                 if !skip_current_key {
                     // Write buffered entries of the previous key to disk
                     for (key, value, version, ts, metadata) in entries_buffer.drain(..) {
@@ -158,7 +158,7 @@ impl StoreInner {
                 }
 
                 // Reset flags for the new key
-                current_key = Some(key.as_ref());
+                current_key = Some(key);
                 skip_current_key = false;
             }
 
@@ -180,7 +180,7 @@ impl StoreInner {
             // Buffer the current entry if not skipping
             if !skip_current_key {
                 entries_buffer.push((
-                    key.as_ref(),
+                    key,
                     value.resolve(&self.core)?,
                     version,
                     ts,

--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -101,7 +101,7 @@ impl StoreInner {
         // Do compaction and write
 
         // Define a closure for writing entries to the temporary commit log
-        let mut write_entry = |key: Box<[u8]>,
+        let mut write_entry = |key: &[u8],
                                value: Box<[u8]>,
                                version: u64,
                                ts: u64,
@@ -133,7 +133,7 @@ impl StoreInner {
             Ok(())
         };
 
-        let mut current_key: Option<Box<[u8]>> = None;
+        let mut current_key: Option<&[u8]> = None;
         let mut entries_buffer = Vec::new();
         let mut skip_current_key = false;
 
@@ -146,7 +146,7 @@ impl StoreInner {
             let metadata = value.metadata();
 
             // If we've moved to a new key, decide whether to write the previous key's entries
-            if Some(&key) != current_key.as_ref() {
+            if Some(&key.as_ref()) != current_key.as_ref() {
                 if !skip_current_key {
                     // Write buffered entries of the previous key to disk
                     for (key, value, version, ts, metadata) in entries_buffer.drain(..) {
@@ -158,7 +158,7 @@ impl StoreInner {
                 }
 
                 // Reset flags for the new key
-                current_key = Some(key.clone());
+                current_key = Some(key.as_ref());
                 skip_current_key = false;
             }
 
@@ -180,10 +180,10 @@ impl StoreInner {
             // Buffer the current entry if not skipping
             if !skip_current_key {
                 entries_buffer.push((
-                    key,
+                    key.as_ref(),
                     value.resolve(&self.core)?,
-                    *version,
-                    *ts,
+                    version,
+                    ts,
                     metadata.cloned(),
                 ));
             }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -304,7 +304,7 @@ mod tests {
             let val = txn.get(&key2).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
-            assert_eq!(val, value);
+            assert_eq!(val.as_ref(), value);
         }
 
         {
@@ -326,7 +326,7 @@ mod tests {
             let val = txn.get(&key3).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
-            assert_eq!(val, value);
+            assert_eq!(val.as_ref(), value);
         }
     }
 
@@ -379,7 +379,7 @@ mod tests {
             let val = txn.get(&key2).unwrap().unwrap();
 
             // Assert that the value retrieved in txn matches the expected value
-            assert_eq!(val, value);
+            assert_eq!(val.as_ref(), value);
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -135,11 +135,11 @@ impl IndexValue {
         }
     }
 
-    pub(crate) fn resolve(&self, store: &Core) -> Result<Vec<u8>> {
+    pub(crate) fn resolve(&self, store: &Core) -> Result<Box<[u8]>> {
         match self {
-            Self::Mem(mem_entry) => Ok(mem_entry.value.to_vec()),
+            Self::Mem(mem_entry) => Ok(Box::from(mem_entry.value.as_ref())),
             Self::Disk(disk_entry) => match &disk_entry.inlined_value {
-                Some(value) => Ok(value.to_vec()),
+                Some(value) => Ok(Box::from(value.as_ref())),
                 None => store.resolve_from_offset(
                     disk_entry.segment_id,
                     disk_entry.value_offset,

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -245,7 +245,7 @@ impl SerializableSnapshotIsolation {
             let range_writes = current_snapshot.range(range.range.clone());
 
             for (key, _, version, _) in range_writes {
-                if *version > txn.read_ts {
+                if version > txn.read_ts {
                     // Check if this key was deleted in current transaction
                     match txn.write_set.get(&key[..]) {
                         Some(entries)

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -247,7 +247,7 @@ impl SerializableSnapshotIsolation {
             for (key, _, version, _) in range_writes {
                 if version > txn.read_ts {
                     // Check if this key was deleted in current transaction
-                    match txn.write_set.get(&key[..]) {
+                    match txn.write_set.get(key) {
                         Some(entries)
                             if entries
                                 .last()

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -394,7 +394,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -429,7 +429,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -480,7 +480,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -527,7 +527,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -574,7 +574,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -631,7 +631,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -674,7 +674,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -716,7 +716,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 
@@ -768,7 +768,7 @@ mod tests {
             // Start a new read-write transaction (txn)
             let mut txn = store.begin().unwrap();
             let val = txn.get(&key).unwrap().unwrap();
-            assert_eq!(val, default_value);
+            assert_eq!(val.as_ref(), default_value);
         }
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -131,20 +131,11 @@ impl Snapshot {
             .collect()
     }
 
-    pub(crate) fn keys_at_ts<'a, R>(
-        &'a self,
-        range: R,
-        ts: u64,
-        limit: Option<usize>,
-    ) -> Vec<&'a [u8]>
+    pub(crate) fn keys_at_ts<'a, R>(&'a self, range: R, ts: u64) -> Vec<&'a [u8]>
     where
         R: RangeBounds<VariableSizeKey> + 'a,
     {
-        let iter = self.snap.keys_at_ts(range, ts);
-        match limit {
-            Some(n) => iter.take(n).collect(),
-            None => iter.collect(),
-        }
+        self.snap.keys_at_ts(range, ts).collect()
     }
 }
 
@@ -203,7 +194,7 @@ mod tests {
 
         let range = "k1".as_bytes()..="k2".as_bytes();
         let keys = txn
-            .keys_at_ts(range.clone(), ts, None)
+            .keys_at_ts(range.clone(), ts)
             .expect("Failed to get keys at timestamp");
         assert_eq!(keys[0], b"k1");
         assert_eq!(keys[1], b"k2");

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -140,7 +140,11 @@ impl Snapshot {
     where
         R: RangeBounds<VariableSizeKey> + 'a,
     {
-        let iter = self.snap.keys_at_ts(range, ts);
+        let iter = self
+            .snap
+            .scan_at_ts(range, ts)
+            .filter(|(_, snap_val, _, _)| !snap_val.deleted())
+            .map(|(key, _, _, _)| (key));
         match limit {
             Some(n) => iter.take(n).collect(),
             None => iter.collect(),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -124,7 +124,6 @@ impl Snapshot {
     {
         self.snap
             .scan_at_ts(range, ts)
-            .into_iter()
             .filter(|(_, snap_val)| !snap_val.deleted())
             .collect()
     }
@@ -206,7 +205,7 @@ mod tests {
             keys_values.len(),
             "Should match the number of keys"
         );
-        let expected = vec![
+        let expected = [
             (Box::from(&b"k1"[..]), Box::from(&b"value1Updated"[..])),
             (Box::from(&b"k2"[..]), Box::from(&b"value2Updated"[..])),
         ];

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -146,23 +146,6 @@ impl Snapshot {
             None => iter.collect(),
         }
     }
-
-    /// Returns just the keys in the given range.
-    pub(crate) fn range_keys<'a, R>(&'a self, range: R, limit: Option<usize>) -> Vec<&'a [u8]>
-    where
-        R: RangeBounds<VariableSizeKey> + 'a,
-    {
-        let base_iter = self
-            .snap
-            .range(range)
-            .filter(|(_, snap_val, _, _)| !snap_val.deleted())
-            .map(|(key, _, _, _)| key);
-
-        match limit {
-            Some(n) => base_iter.take(n).collect(),
-            None => base_iter.collect(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -126,7 +126,6 @@ impl Snapshot {
     {
         self.snap
             .scan_at_ts(range, ts)
-            .into_iter()
             .filter(|(_, snap_val, _, _)| !snap_val.deleted())
             .map(|(key, snap_val, _, _)| (key, snap_val.clone()))
             .collect()

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -505,8 +505,7 @@ impl Transaction {
 
         // Get a snapshot iterator for the specified range.
         let snap = self.snapshot.as_ref().unwrap();
-        let snap_iter = snap
-            .range(bound_range.clone());
+        let snap_iter = snap.range(bound_range.clone());
 
         Self::merging_scan(
             &self.core,
@@ -533,9 +532,7 @@ impl Transaction {
         // Convert the range to a tuple of bounds of variable keys.
         let range = convert_range_bounds(&range);
         let keys = self.snapshot.as_ref().unwrap().range_with_deleted(range);
-        let iter = keys
-            .into_iter()
-            .map(|(key, _, _, _)| Box::from(key));
+        let iter = keys.into_iter().map(|(key, _, _, _)| Box::from(key));
 
         let result = match limit {
             Some(n) => iter.take(n).collect(),
@@ -837,20 +834,6 @@ impl Transaction {
         // Convert the range to a tuple of bounds of variable keys.
         let range = convert_range_bounds(&range);
         let keys = self.snapshot.as_ref().unwrap().keys_at_ts(range, ts, limit);
-
-        Ok(keys)
-    }
-
-    /// Returns only keys within the specified range.
-    pub fn keys<'b, R>(&'b self, range: R, limit: Option<usize>) -> Result<Vec<&'b [u8]>>
-    where
-        R: RangeBounds<&'b [u8]>,
-    {
-        self.ensure_read_only_transaction()?;
-
-        // Convert the range to a tuple of bounds of variable keys.
-        let range = convert_range_bounds(&range);
-        let keys = self.snapshot.as_ref().unwrap().range_keys(range, limit);
 
         Ok(keys)
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -65,6 +65,12 @@ pub type ScanResult = (Box<[u8]>, Box<[u8]>, u64);
 /// ScanResult is a tuple containing the key, value, timestamp, and info about whether the key is deleted.
 pub type ScanVersionResult = (Box<[u8]>, Box<[u8]>, u64, bool);
 
+// For scan_at_ts return type
+type ScanTsResult = Vec<(Box<[u8]>, Box<[u8]>)>;
+
+// For get_value_by_query return type
+type QueryResult = Option<(Box<[u8]>, u64, u64)>;
+
 #[derive(Default, Debug, Copy, Clone)]
 pub enum Durability {
     /// Commits with this durability level are guaranteed to be persistent eventually. The data
@@ -780,7 +786,7 @@ impl Transaction {
         range: R,
         ts: u64,
         limit: Option<usize>,
-    ) -> Result<Vec<(Box<[u8]>, Box<[u8]>)>>
+    ) -> Result<ScanTsResult>
     where
         R: RangeBounds<&'b [u8]>,
     {
@@ -828,7 +834,7 @@ impl Transaction {
         &self,
         key: &VariableSizeKey,
         query_type: QueryType,
-    ) -> Result<Option<(Box<[u8]>, u64, u64)>> {
+    ) -> Result<QueryResult> {
         self.ensure_read_only_transaction()?;
 
         match self

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -820,12 +820,7 @@ impl Transaction {
     }
 
     /// Returns keys within the specified range, at the given timestamp.
-    pub fn keys_at_ts<'b, R>(
-        &'b self,
-        range: R,
-        ts: u64,
-        limit: Option<usize>,
-    ) -> Result<Vec<&'b [u8]>>
+    pub fn keys_at_ts<'b, R>(&'b self, range: R, ts: u64) -> Result<Vec<&'b [u8]>>
     where
         R: RangeBounds<&'b [u8]>,
     {
@@ -833,7 +828,7 @@ impl Transaction {
 
         // Convert the range to a tuple of bounds of variable keys.
         let range = convert_range_bounds(&range);
-        let keys = self.snapshot.as_ref().unwrap().keys_at_ts(range, ts, limit);
+        let keys = self.snapshot.as_ref().unwrap().keys_at_ts(range, ts);
 
         Ok(keys)
     }


### PR DESCRIPTION
## Description

This PR adds a filter to the `keys_at_ts` method to filter out deleted keys.