### PR TITLE
fsync on segment reopen

### DIFF
--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -684,7 +684,12 @@ impl Segment {
 
         // Only open write handle if not read_only
         let mut write_file = if !read_only {
-            Some(Self::open_file(&file_path, opts, true)?)
+            let file = Self::open_file(&file_path, opts, true)?;
+
+            // Should fsync here to ensure any previous unflushed
+            // page cache in the kernel (because of previous crash) is flushed to disk
+            file.sync_all()?;
+            Some(file)
         } else {
             None
         };


### PR DESCRIPTION
## Description

This PR adds fsync when opening the latest segment file, ensuring that any writes made before a crash are safely persisted. If a user process crashes after writing to the latest segment but before calling fsync, the page cache in the kernel will retain those writes. The next process to open the latest segment will access this cached data, immediately calling fsync to persist it to disk.