### PR TITLE
Remove dependency on snapshot during commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,3 @@ walkdir = "2.5.0"
 [[bench]]
 name = "store_bench"
 harness = false
-
-[[bench]]
-name = "load_bench"
-harness = false

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -466,6 +466,9 @@ impl Transaction {
             return Ok(()); // Return when there's nothing to commit
         }
 
+        // Drop the snapshot to avoid holding references in the index.
+        self.snapshot.take();
+
         // Serialize commits to the transaction log.
         let write_ch_lock = self.core.commit_write_lock.lock();
 


### PR DESCRIPTION
This PR clears the transaction snapshot prior to commit. Since there is no dependency on the transaction snapshot during the commit phase, this could help have less references in vart to certain nodes.