### PR TITLE
Fix compaction on Windows by ensuring file handles are released before renaming

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -196,6 +196,10 @@ impl Store {
 
         temp_writer.close()?;
 
+        // Explicitly drop temp_writer and manifest to release file handles before renaming
+        drop(temp_writer);
+        drop(manifest);
+
         // Finalize compaction by renaming the temporary directory
         fs::rename(tmp_merge_dir, merge_dir)?;
 


### PR DESCRIPTION
This PR fixes a compaction failure on Windows caused by open file handles preventing the rename operation. Explicitly dropping temp_writer and manifest before the rename ensures the resources are freed, allowing the compaction process to complete successfully. Additionally, verified that all compaction tests now pass on Windows.

Fixes #194 