### PR TITLE
SurrealDB Improvements: Replace API, Versioning, and Iterator Enhancements

### DIFF
--- a/src/bplustree/tree.rs
+++ b/src/bplustree/tree.rs
@@ -2211,50 +2211,51 @@ impl<F: VfsFile> Iterator for RangeScanIterator<'_, F> {
 	type Item = Result<(Vec<u8>, Vec<u8>)>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		if self.reached_end {
-			return None;
-		}
+		loop {
+			if self.reached_end {
+				return None;
+			}
 
-		if let Some(leaf) = &self.current_leaf {
-			// Check if we've reached the end of the current leaf
-			if self.current_idx >= leaf.keys.len() {
-				// Move to the next leaf if possible
-				if leaf.next_leaf == 0 {
+			if let Some(leaf) = &self.current_leaf {
+				// Check if we've reached the end of the current leaf
+				if self.current_idx >= leaf.keys.len() {
+					// Move to the next leaf if possible
+					if leaf.next_leaf == 0 {
+						self.reached_end = true;
+						return None;
+					}
+
+					// Load the next leaf
+					match self.tree.read_node(leaf.next_leaf) {
+						Ok(NodeType::Leaf(next_leaf)) => {
+							self.current_leaf = Some(next_leaf);
+							self.current_idx = 0;
+							// Continue the loop
+							continue;
+						}
+						Ok(_) => return Some(Err(BPlusTreeError::InvalidNodeType)),
+						Err(e) => return Some(Err(e)),
+					}
+				}
+
+				// Check if the current key is within range
+				let key = &leaf.keys[self.current_idx];
+				if self.tree.compare.compare(key, &self.end_key) == Ordering::Greater {
 					self.reached_end = true;
 					return None;
 				}
 
-				// Load the next leaf
-				match self.tree.read_node(leaf.next_leaf) {
-					Ok(NodeType::Leaf(next_leaf)) => {
-						self.current_leaf = Some(next_leaf);
-						self.current_idx = 0;
-						// Recursively call next() to process the new leaf
-						return self.next();
-					}
-					Ok(_) => return Some(Err(BPlusTreeError::InvalidNodeType)),
-					Err(e) => return Some(Err(e)),
-				}
+				// Return the current key-value pair and advance
+				let result = Ok((key.clone(), leaf.values[self.current_idx].clone()));
+				self.current_idx += 1;
+				return Some(result);
 			}
 
-			// Check if the current key is within range
-			let key = &leaf.keys[self.current_idx];
-			if self.tree.compare.compare(key, &self.end_key) == Ordering::Greater {
-				self.reached_end = true;
-				return None;
-			}
-
-			// Return the current key-value pair and advance
-			let result = Ok((key.clone(), leaf.values[self.current_idx].clone()));
-			self.current_idx += 1;
-			return Some(result);
+			self.reached_end = true;
+			return None;
 		}
-
-		self.reached_end = true;
-		None
 	}
 }
-
 #[cfg(test)]
 mod tests {
 	use std::fs::File;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -181,7 +181,7 @@ impl DatabaseCheckpoint {
 
 		// Step 2: Get current sequence number from the levels
 		let sequence_number = {
-			let levels_guard = self.core.level_manifest.as_ref().unwrap().read()?;
+			let levels_guard = self.core.level_manifest.read()?;
 			levels_guard.lsn()
 		};
 
@@ -292,7 +292,7 @@ impl DatabaseCheckpoint {
 
 	/// Copies all SSTables to the checkpoint directory
 	fn copy_sstables(&self, dest_dir: &Path) -> Result<(usize, u64)> {
-		let levels_guard = self.core.level_manifest.as_ref().unwrap().read()?;
+		let levels_guard = self.core.level_manifest.read()?;
 		let mut total_size = 0u64;
 		let mut count = 0usize;
 

--- a/src/compaction/compactor.rs
+++ b/src/compaction/compactor.rs
@@ -30,10 +30,7 @@ impl CompactionOptions {
 	pub(crate) fn from(tree: &CoreInner) -> Self {
 		Self {
 			lopts: tree.opts.clone(),
-			level_manifest: tree
-				.level_manifest
-				.clone()
-				.expect("Compaction requires level manifest"),
+			level_manifest: tree.level_manifest.clone(),
 			immutable_memtables: tree.immutable_memtables.clone(),
 			vlog: tree.vlog.clone(),
 		}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -234,7 +234,6 @@ impl<'a> CompactionIterator<'a> {
 	pub(crate) fn flush_delete_list_batch(&mut self) -> Result<()> {
 		if let Some(ref vlog) = self.vlog {
 			if !self.delete_list_batch.is_empty() {
-				println!("Flushing delete list batch: {:?}", self.delete_list_batch);
 				vlog.add_batch_to_delete_list(std::mem::take(&mut self.delete_list_batch))?;
 			}
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,6 @@ pub struct Options {
 	pub vlog_gc_discard_ratio: f64,
 	/// If value size is less than this, it will be stored inline in `SSTable`
 	pub vlog_value_threshold: usize,
-	/// If true, runs the LSM store completely in memory
-	pub in_memory_only: bool,
 
 	// Versioned query configuration
 	/// If true, enables versioned queries with timestamp tracking
@@ -111,7 +109,6 @@ impl Default for Options {
 			enable_vlog: false,
 			vlog_gc_discard_ratio: 0.5, // 50% default
 			vlog_value_threshold: 4096, // 4KB default
-			in_memory_only: false,
 			enable_versioning: false,
 			versioned_history_retention_ns: 0, // No retention limit by default
 			clock,
@@ -204,17 +201,6 @@ impl Options {
 	pub fn with_vlog_gc_discard_ratio(mut self, value: f64) -> Self {
 		assert!((0.0..=1.0).contains(&value), "VLog GC discard ratio must be between 0.0 and 1.0");
 		self.vlog_gc_discard_ratio = value;
-		self
-	}
-
-	/// Sets the in-memory only mode.
-	///
-	/// When enabled, the LSM store will run completely in memory without:
-	/// - WAL (Write-Ahead Log)
-	/// - Compactor and task manager
-	/// - Disk persistence
-	pub const fn with_in_memory_only(mut self, value: bool) -> Self {
-		self.in_memory_only = value;
 		self
 	}
 
@@ -337,13 +323,6 @@ impl Options {
 			if self.vlog_value_threshold > 0 {
 				return Err(Error::InvalidArgument(
 					"Versioned queries require all values to be stored in VLog. Set vlog_value_threshold to 0.".to_string(),
-				));
-			}
-
-			// Versioned queries don't work in memory-only mode (need persistence for history)
-			if self.in_memory_only {
-				return Err(Error::InvalidArgument(
-					"Versioned queries require persistence. Cannot use in_memory_only mode with versioned queries.".to_string(),
 				));
 			}
 		}

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -91,9 +91,7 @@ pub(crate) struct CoreInner {
 	/// - L0: Contains SSTables flushed directly from memtables. May have overlapping key ranges.
 	/// - L1+: Each level is larger than the previous. SSTables have non-overlapping
 	///   key ranges within a level, enabling efficient binary search.
-	///
-	/// In memory-only mode, this is None since we don't persist to disk.
-	pub level_manifest: Option<Arc<RwLock<LevelManifest>>>,
+	pub level_manifest: Arc<RwLock<LevelManifest>>,
 
 	/// Configuration options controlling LSM tree behavior
 	pub opts: Arc<Options>,
@@ -110,7 +108,6 @@ pub(crate) struct CoreInner {
 	pub(crate) vlog: Option<Arc<VLog>>,
 
 	/// Write-Ahead Log (WAL) for durability
-	/// In memory-only mode, this is None since we don't persist to disk.
 	pub(crate) wal: Option<parking_lot::RwLock<Wal>>,
 
 	/// Versioned B+ tree index for timestamp-based queries
@@ -130,20 +127,14 @@ impl CoreInner {
 		// The oracle provides monotonic timestamps for transaction ordering
 		let oracle = Oracle::new(opts.clock.clone());
 
-		// Initialize WAL and level manifest only if not in memory-only mode
-		let (wal, level_manifest) = if opts.in_memory_only {
-			// In memory-only mode, we don't need WAL or level manifest since we don't persist to disk
-			(None, None)
-		} else {
-			let wal_path = opts.wal_dir();
-			let wal = Some(Wal::open(&wal_path, wal::Options::default())?);
-			let manifest = LevelManifest::new(opts.clone())?;
-			let level_manifest = Some(Arc::new(RwLock::new(manifest)));
-			(wal, level_manifest)
-		};
+		// Initialize WAL and level manifest
+		let wal_path = opts.wal_dir();
+		let wal = Some(Wal::open(&wal_path, wal::Options::default())?);
+		let manifest = LevelManifest::new(opts.clone())?;
+		let level_manifest = Arc::new(RwLock::new(manifest));
 
 		// Initialize versioned index if versioned queries are enabled
-		let versioned_index = if opts.enable_versioning && !opts.in_memory_only {
+		let versioned_index = if opts.enable_versioning {
 			// Create the versioned index directory if it doesn't exist
 			let versioned_index_dir = opts.versioned_index_dir();
 			let versioned_index_path = versioned_index_dir.join("index.bpt");
@@ -156,7 +147,7 @@ impl CoreInner {
 			None
 		};
 
-		let vlog = if opts.enable_vlog && !opts.in_memory_only {
+		let vlog = if opts.enable_vlog {
 			Some(Arc::new(VLog::new(opts.clone(), versioned_index.clone())?))
 		} else {
 			None
@@ -230,7 +221,7 @@ impl CoreInner {
 		let flushed_memtable = std::mem::take(&mut *active_memtable);
 
 		// Track the immutable memtable until it's successfully flushed
-		let memtable_id = self.level_manifest.as_ref().unwrap().read()?.next_table_id();
+		let memtable_id = self.level_manifest.read()?.next_table_id();
 		immutable_memtables.add(memtable_id, flushed_memtable.clone());
 
 		// Now rotate the WAL while still holding the active_memtable lock
@@ -252,7 +243,7 @@ impl CoreInner {
 	/// - Queries must check all L0 SSTables
 	/// - Too many L0 files triggers compaction to maintain read performance
 	fn add_table_to_l0(&self, table: Arc<Table>) -> Result<()> {
-		let mut original_manifest = self.level_manifest.as_ref().unwrap().write()?;
+		let mut original_manifest = self.level_manifest.write()?;
 		let mut memtable_lock = self.immutable_memtables.write()?;
 		let table_id = table.id;
 
@@ -375,7 +366,6 @@ struct LsmCommitEnv {
 	core: Arc<CoreInner>,
 
 	/// Manages background tasks like flushing and compaction
-	/// In memory-only mode, this is None since we don't need background tasks
 	task_manager: Option<Arc<TaskManager>>,
 }
 
@@ -385,14 +375,6 @@ impl LsmCommitEnv {
 		Ok(Self {
 			core,
 			task_manager: Some(task_manager),
-		})
-	}
-
-	/// Creates a new commit environment for in-memory mode (without task manager)
-	pub(crate) fn new_in_memory(core: Arc<CoreInner>) -> Result<Self> {
-		Ok(Self {
-			core,
-			task_manager: None,
 		})
 	}
 }
@@ -652,62 +634,46 @@ impl Core {
 	pub(crate) fn new(opts: Arc<Options>) -> Result<Self> {
 		let inner = Arc::new(CoreInner::new(opts.clone())?);
 
-		if opts.in_memory_only {
-			// For in-memory mode, create a minimal core without background tasks
-			let commit_env = Arc::new(LsmCommitEnv::new_in_memory(inner.clone())?);
-			let commit_pipeline = CommitPipeline::new(commit_env);
+		// Initialize background task manager
+		let task_manager = Arc::new(TaskManager::new(inner.clone()));
 
-			// Set initial sequence number
-			commit_pipeline.set_seq_num(1);
+		let commit_env = Arc::new(LsmCommitEnv::new(inner.clone(), task_manager.clone())?);
 
-			Ok(Self {
-				inner: inner.clone(),
-				commit_pipeline: commit_pipeline.clone(),
-				task_manager: Mutex::new(None),
-				vlog_gc_manager: Mutex::new(None),
-			})
-		} else {
-			// Initialize background task manager
-			let task_manager = Arc::new(TaskManager::new(inner.clone()));
+		let commit_pipeline = CommitPipeline::new(commit_env);
 
-			let commit_env = Arc::new(LsmCommitEnv::new(inner.clone(), task_manager.clone())?);
+		// Path for the WAL directory
+		let wal_path = opts.wal_dir();
 
-			let commit_pipeline = CommitPipeline::new(commit_env);
+		// Replay WAL with automatic repair on corruption
+		let wal_seq_num =
+			Self::replay_wal_with_repair(&wal_path, "Database startup", |memtable| {
+				let mut active_memtable = inner.active_memtable.write()?;
+				*active_memtable = memtable;
+				Ok(())
+			})?;
 
-			// Path for the WAL directory
-			let wal_path = opts.wal_dir();
+		// Update sequence number to max of LSM sequence number and WAL sequence number
+		let current_seq_num = inner.level_manifest.read()?.lsn();
+		let max_seq_num = std::cmp::max(current_seq_num, wal_seq_num);
 
-			// Replay WAL with automatic repair on corruption
-			let wal_seq_num =
-				Self::replay_wal_with_repair(&wal_path, "Database startup", |memtable| {
-					let mut active_memtable = inner.active_memtable.write()?;
-					*active_memtable = memtable;
-					Ok(())
-				})?;
+		// Set visible sequence number ts to highest of lsn from Wal, or latest table in manifest
+		commit_pipeline.set_seq_num(max_seq_num);
 
-			// Update sequence number to max of LSM sequence number and WAL sequence number
-			let current_seq_num = inner.level_manifest.as_ref().unwrap().read()?.lsn();
-			let max_seq_num = std::cmp::max(current_seq_num, wal_seq_num);
+		let core = Self {
+			inner: inner.clone(),
+			commit_pipeline: commit_pipeline.clone(),
+			task_manager: Mutex::new(Some(task_manager)),
+			vlog_gc_manager: Mutex::new(None),
+		};
 
-			// Set visible sequence number ts to highest of lsn from Wal, or latest table in manifest
-			commit_pipeline.set_seq_num(max_seq_num);
-
-			let core = Self {
-				inner: inner.clone(),
-				commit_pipeline: commit_pipeline.clone(),
-				task_manager: Mutex::new(Some(task_manager)),
-				vlog_gc_manager: Mutex::new(None),
-			};
-
-			// Initialize VLog GC manager only if VLog is enabled
-			if let Some(ref vlog) = inner.vlog {
-				let vlog_gc_manager = VLogGCManager::new(vlog.clone(), commit_pipeline.clone());
-				vlog_gc_manager.start();
-				*core.vlog_gc_manager.lock().unwrap() = Some(vlog_gc_manager);
-			}
-
-			Ok(core)
+		// Initialize VLog GC manager only if VLog is enabled
+		if let Some(ref vlog) = inner.vlog {
+			let vlog_gc_manager = VLogGCManager::new(vlog.clone(), commit_pipeline.clone());
+			vlog_gc_manager.start();
+			*core.vlog_gc_manager.lock().unwrap() = Some(vlog_gc_manager);
 		}
+
+		Ok(core)
 	}
 
 	pub(crate) async fn commit(&self, batch: Batch, sync: bool) -> Result<()> {
@@ -742,12 +708,9 @@ impl Core {
 		}
 
 		// Step 3: Flush the active memtable only if it exceeds the configured size
-		// Skip this in memory-only mode since we don't persist to disk
-		if !self.inner.opts.in_memory_only {
-			let active_memtable = self.inner.active_memtable.read()?;
-			if active_memtable.size() > self.inner.opts.max_memtable_size {
-				self.inner.compact_memtable()?;
-			}
+		let active_memtable = self.inner.active_memtable.read()?;
+		if active_memtable.size() > self.inner.opts.max_memtable_size {
+			self.inner.compact_memtable()?;
 		}
 
 		// Step 4: Close the WAL to ensure all data is flushed
@@ -758,7 +721,6 @@ impl Core {
 		}
 
 		// Step 5: Flush all directories to ensure durability
-		// Skip this in memory-only mode since we don't persist to disk
 		sync_directory_structure(&self.inner.opts)?;
 
 		Ok(())
@@ -795,10 +757,6 @@ impl Tree {
 
 	/// Creates all required directory structure for the LSM tree
 	fn create_directory_structure(opts: &Options) -> Result<()> {
-		if opts.in_memory_only {
-			return Ok(());
-		}
-
 		// Create base directory
 		create_dir_all(&opts.path)?;
 
@@ -879,7 +837,7 @@ impl Tree {
 
 		// Replace the current levels with the reloaded ones
 		{
-			let mut levels_guard = self.core.inner.level_manifest.as_ref().unwrap().write()?;
+			let mut levels_guard = self.core.inner.level_manifest.write()?;
 			*levels_guard = new_levels;
 		}
 
@@ -913,7 +871,7 @@ impl Tree {
 			})?;
 
 		// Update sequence number to max of LSM sequence number and WAL sequence number
-		let current_seq_num = self.core.inner.level_manifest.as_ref().unwrap().read()?.lsn();
+		let current_seq_num = self.core.inner.level_manifest.read()?.lsn();
 		let max_seq_num = std::cmp::max(current_seq_num, wal_seq_num);
 
 		// Set visible sequence number to highest of lsn from WAL or latest table in manifest
@@ -1088,12 +1046,6 @@ impl TreeBuilder {
 		self
 	}
 
-	/// Sets the in-memory only mode.
-	pub fn with_in_memory_only(mut self, in_memory: bool) -> Self {
-		self.opts = self.opts.with_in_memory_only(in_memory);
-		self
-	}
-
 	/// Enables or disables versioned queries with timestamp tracking
 	pub fn with_versioning(mut self, enable: bool, retention_ns: u64) -> Self {
 		self.opts = self.opts.with_versioning(enable, retention_ns);
@@ -1141,10 +1093,6 @@ pub(crate) fn fsync_directory<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
 /// Syncs all directory structures for the LSM store to ensure durability
 /// Returns explicit errors indicating which path failed
 fn sync_directory_structure(opts: &Options) -> Result<()> {
-	if opts.in_memory_only {
-		return Ok(());
-	}
-
 	// Sync all subdirectories with explicit error handling
 	fsync_directory(opts.sstable_dir()).map_err(|e| {
 		Error::Other(format!(
@@ -1408,10 +1356,7 @@ mod tests {
 		}
 
 		// Verify the LSM state: we should have multiple SSTables
-		let l0_size =
-			tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()[0]
-				.tables
-				.len();
+		let l0_size = tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 		assert!(l0_size > 0, "Expected SSTables in L0, got {l0_size}");
 	}
 
@@ -1464,9 +1409,7 @@ mod tests {
 
 			// Verify L0 has tables before closing
 			let l0_size =
-				tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()[0]
-					.tables
-					.len();
+				tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 			assert!(l0_size > 0, "Expected SSTables in L0 before closing, got {l0_size}");
 
 			// Tree will be dropped here, closing the store
@@ -1479,9 +1422,7 @@ mod tests {
 
 			// Verify L0 has tables after reopening
 			let l0_size =
-				tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()[0]
-					.tables
-					.len();
+				tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 			assert!(l0_size > 0, "Expected SSTables in L0 after reopening, got {l0_size}");
 
 			// Verify all keys have their final values
@@ -3007,14 +2948,12 @@ mod tests {
 
 			// Verify we have 2 tables in L0
 			let l0_size =
-				tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()[0]
-					.tables
-					.len();
+				tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 			assert_eq!(l0_size, 2, "Expected 2 tables in L0 after initial writes, got {l0_size}");
 
 			// Get the table IDs from the first session
 			let (table1_id, table2_id, next_table_id) = {
-				let manifest = tree.core.level_manifest.as_ref().unwrap().read().unwrap();
+				let manifest = tree.core.level_manifest.read().unwrap();
 				let table1_id = manifest.levels.get_levels()[0].tables[0].id;
 				let table2_id = manifest.levels.get_levels()[0].tables[1].id;
 				let next_table_id = manifest.next_table_id();
@@ -3043,13 +2982,10 @@ mod tests {
 			{
 				// Verify we still have 2 tables in L0 after reopening
 				let l0_size =
-					tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()
-						[0]
-					.tables
-					.len();
+					tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 				assert_eq!(l0_size, 2, "Expected 2 tables in L0 after reopening, got {l0_size}");
 				// Get the table IDs after reopening
-				let manifest = tree.core.level_manifest.as_ref().unwrap().read().unwrap();
+				let manifest = tree.core.level_manifest.read().unwrap();
 				let table1_id = manifest.levels.get_levels()[0].tables[0].id;
 				let table2_id = manifest.levels.get_levels()[0].tables[1].id;
 				let next_table_id = manifest.next_table_id();
@@ -3081,17 +3017,14 @@ mod tests {
 			{
 				// Verify we now have 3 tables in L0
 				let l0_size =
-					tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()
-						[0]
-					.tables
-					.len();
+					tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 				assert_eq!(
 					l0_size, 3,
 					"Expected 3 tables in L0 after adding more data, got {l0_size}"
 				);
 
 				// Get the table IDs from all 3 tables
-				let manifest = tree.core.level_manifest.as_ref().unwrap().read().unwrap();
+				let manifest = tree.core.level_manifest.read().unwrap();
 				let table1_id = manifest.levels.get_levels()[0].tables[0].id;
 				let table2_id = manifest.levels.get_levels()[0].tables[1].id;
 				let table3_id = manifest.levels.get_levels()[0].tables[2].id;
@@ -3135,13 +3068,11 @@ mod tests {
 
 			// Verify we still have 3 tables
 			let l0_size =
-				tree.core.level_manifest.as_ref().unwrap().read().unwrap().levels.get_levels()[0]
-					.tables
-					.len();
+				tree.core.level_manifest.read().unwrap().levels.get_levels()[0].tables.len();
 			assert_eq!(l0_size, 3, "Expected 3 tables in L0 after final reopen, got {l0_size}");
 
 			// Verify table IDs are still in correct order (newer tables first)
-			let manifest = tree.core.level_manifest.as_ref().unwrap().read().unwrap();
+			let manifest = tree.core.level_manifest.read().unwrap();
 			let table1_id = manifest.levels.get_levels()[0].tables[0].id;
 			let table2_id = manifest.levels.get_levels()[0].tables[1].id;
 			let table3_id = manifest.levels.get_levels()[0].tables[2].id;
@@ -3165,89 +3096,6 @@ mod tests {
 			let result = txn.get("batch_0_key_000".as_bytes()).unwrap();
 			assert!(result.is_some(), "Should be able to read at least one key");
 		}
-	}
-
-	#[tokio::test]
-	async fn test_in_memory_only_mode() {
-		let temp_dir = create_temp_directory();
-		let path = temp_dir.path().to_path_buf();
-
-		// Create options with in-memory mode enabled
-		let opts = create_test_options(path.clone(), |opts| {
-			opts.in_memory_only = true;
-		});
-
-		let tree = Tree::new(opts.clone()).unwrap();
-
-		// Test basic operations
-		let key = "test_key";
-		let value = "test_value";
-
-		// Insert a key-value pair
-		let mut txn = tree.begin().unwrap();
-		txn.set(key.as_bytes(), value.as_bytes()).unwrap();
-		txn.commit().await.unwrap();
-
-		// Read back the key-value pair
-		let txn = tree.begin().unwrap();
-		let result = txn.get(key.as_bytes()).unwrap().unwrap();
-		assert_eq!(result, value.as_bytes().into());
-
-		// Test multiple operations
-		for i in 0..10 {
-			let key = format!("key_{}", i);
-			let value = format!("value_{}", i);
-
-			let mut txn = tree.begin().unwrap();
-			txn.set(key.as_bytes(), value.as_bytes()).unwrap();
-			txn.commit().await.unwrap();
-		}
-
-		// Verify all keys exist
-		for i in 0..10 {
-			let key = format!("key_{}", i);
-			let expected_value = format!("value_{}", i);
-
-			let txn = tree.begin().unwrap();
-			let result = txn.get(key.as_bytes()).unwrap().unwrap();
-			assert_eq!(result, expected_value.as_bytes().into());
-		}
-
-		// Test range scan
-		let txn = tree.begin().unwrap();
-		let range_result: Vec<_> =
-			txn.range(b"key_0", b"key_9", None).unwrap().map(|r| r.unwrap()).collect::<Vec<_>>();
-
-		assert_eq!(range_result.len(), 10, "Range scan should return 10 items");
-
-		// Test delete
-		let mut txn = tree.begin().unwrap();
-		txn.delete("key_5".as_bytes()).unwrap();
-		txn.commit().await.unwrap();
-
-		let txn = tree.begin().unwrap();
-		let result = txn.get("key_5".as_bytes()).unwrap();
-		assert!(result.is_none(), "Deleted key should not exist");
-
-		// Verify other keys still exist
-		let txn = tree.begin().unwrap();
-		let result = txn.get("key_4".as_bytes()).unwrap().unwrap();
-		assert_eq!(result, "value_4".as_bytes().into());
-
-		// Verify that level_manifest is None in memory-only mode
-		assert!(
-			tree.core.level_manifest.is_none(),
-			"Level manifest should be None in memory-only mode"
-		);
-
-		// Verify that WAL is None in memory-only mode
-		assert!(tree.core.wal.is_none(), "WAL should be None in memory-only mode");
-
-		// Verify that task_manager is None in memory-only mode
-		assert!(
-			tree.core.task_manager.lock().unwrap().is_none(),
-			"Task manager should be None in memory-only mode"
-		);
 	}
 
 	#[tokio::test(flavor = "multi_thread")]
@@ -3350,7 +3198,6 @@ mod tests {
 			.with_max_memtable_size(64 * 1024)
 			.with_enable_vlog(true)
 			.with_vlog_max_file_size(1024 * 1024)
-			.with_in_memory_only(false)
 			.build()
 			.unwrap();
 
@@ -3366,12 +3213,10 @@ mod tests {
 		// Test build_with_options
 		let (tree2, opts) = TreeBuilder::new()
 			.with_path(temp_dir.path().join("tree2"))
-			.with_in_memory_only(true)
 			.build_with_options()
 			.unwrap();
 
 		// Verify the options are accessible
-		assert!(opts.in_memory_only);
 		assert_eq!(opts.path, temp_dir.path().join("tree2"));
 
 		// Test basic operations on the second tree

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -467,7 +467,7 @@ impl CommitEnv for LsmCommitEnv {
 						InternalKey::new(user_key.clone(), 0, InternalKeyKind::Set, 0).encode();
 					let end_key = InternalKey::new(
 						user_key.clone(),
-						u64::MAX,
+						seq_num,
 						InternalKeyKind::Max,
 						INTERNAL_KEY_TIMESTAMP_MAX,
 					)

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -478,8 +478,8 @@ impl CommitEnv for LsmCommitEnv {
 			for (encoded_key, encoded_value) in timestamp_entries {
 				let ikey = InternalKey::decode(&encoded_key);
 
-				if ikey.is_set_with_delete() {
-					// For SetWithDelete: first delete all existing entries for this user key
+				if ikey.is_replace() {
+					// For Replace: first delete all existing entries for this user key
 					let user_key = ikey.user_key.as_ref().to_vec();
 					let start_key =
 						InternalKey::new(user_key.clone(), 0, InternalKeyKind::Set, 0).encode();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -443,7 +443,7 @@ impl Snapshot {
 				key_versions
 					.entry(current_key)
 					.or_default()
-					.push((internal_key, encoded_value.clone()));
+					.push((internal_key, encoded_value.to_vec()));
 			}
 
 			// Filter out keys where the latest version is a hard delete

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -179,32 +179,26 @@ impl Snapshot {
 		drop(memtable_lock); // Release the lock on the immutable memtables
 
 		// Read lock on the level manifest
-		if let Some(ref level_manifest) = self.core.level_manifest {
-			let level_manifest = level_manifest.read()?;
+		let level_manifest = self.core.level_manifest.read()?;
 
-			// Check the tables in each level for the key
-			for level in &level_manifest.levels {
-				for table in level.tables.iter() {
-					let ikey = InternalKey::new(
-						key.as_ref().to_vec(),
-						self.seq_num,
-						InternalKeyKind::Set,
-						0,
-					);
+		// Check the tables in each level for the key
+		for level in &level_manifest.levels {
+			for table in level.tables.iter() {
+				let ikey =
+					InternalKey::new(key.as_ref().to_vec(), self.seq_num, InternalKeyKind::Set, 0);
 
-					if !table.is_key_in_key_range(&ikey) {
-						continue; // Skip this table if the key is not in its range
+				if !table.is_key_in_key_range(&ikey) {
+					continue; // Skip this table if the key is not in its range
+				}
+
+				let maybe_item = table.get(ikey)?;
+
+				if let Some(item) = maybe_item {
+					let ikey = &item.0;
+					if ikey.is_tombstone() {
+						return Ok(None); // Key is a tombstone, return None
 					}
-
-					let maybe_item = table.get(ikey)?;
-
-					if let Some(item) = maybe_item {
-						let ikey = &item.0;
-						if ikey.is_tombstone() {
-							return Ok(None); // Key is a tombstone, return None
-						}
-						return Ok(Some((item.1, ikey.seq_num()))); // Key found, return the value
-					}
+					return Ok(Some((item.1, ikey.seq_num()))); // Key found, return the value
 				}
 			}
 		}
@@ -958,20 +952,11 @@ impl SnapshotIterator<'_> {
 			guardian::ArcRwLockReadGuardian::take(core.immutable_memtables.clone()).unwrap();
 
 		// Collect iterators from all tables in all levels
-		let iter_state: IterState = if let Some(ref level_manifest) = core.level_manifest {
-			let manifest = guardian::ArcRwLockReadGuardian::take(level_manifest.clone()).unwrap();
-			IterState {
-				active: active.clone(),
-				immutable: immutable.iter().map(|(_, mt)| mt.clone()).collect(),
-				levels: manifest.levels.clone(),
-			}
-		} else {
-			// In memory-only mode, only use memtables
-			IterState {
-				active: active.clone(),
-				immutable: immutable.iter().map(|(_, mt)| mt.clone()).collect(),
-				levels: Levels(vec![]), // Empty levels
-			}
+		let manifest = guardian::ArcRwLockReadGuardian::take(core.level_manifest.clone()).unwrap();
+		let iter_state = IterState {
+			active: active.clone(),
+			immutable: immutable.iter().map(|(_, mt)| mt.clone()).collect(),
+			levels: manifest.levels.clone(),
 		};
 
 		// Convert bounds to owned for passing to merge iterator

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -226,7 +226,7 @@ impl Snapshot {
 
 	/// Queries the versioned index for a specific key at a specific timestamp
 	/// Only returns data visible to this snapshot (seq_num <= snapshot.seq_num)
-	pub(crate) fn get_at_timestamp(&self, key: &[u8], timestamp: u64) -> Result<Option<Value>> {
+	pub(crate) fn get_at_version(&self, key: &[u8], timestamp: u64) -> Result<Option<Value>> {
 		// Create a range that includes only the specific key
 		let key_range = key.to_vec()..=key.to_vec();
 
@@ -250,12 +250,12 @@ impl Snapshot {
 
 	/// Gets keys in a key range at a specific timestamp
 	/// Only returns data visible to this snapshot (seq_num <= snapshot.seq_num)
-	pub(crate) fn keys_at_timestamp<'a, R: RangeBounds<Vec<u8>>>(
+	pub(crate) fn keys_at_version<'a, R: RangeBounds<Vec<u8>>>(
 		&'a self,
 		key_range: R,
 		timestamp: u64,
 		limit: Option<usize>,
-	) -> Result<impl DoubleEndedIterator<Item = Result<Vec<u8>>> + 'a> {
+	) -> Result<impl DoubleEndedIterator<Item = Vec<u8>> + 'a> {
 		let versioned_iter = self.versioned_range_iter(VersionedRangeQueryParams {
 			key_range: &key_range,
 			start_ts: 0,
@@ -273,7 +273,7 @@ impl Snapshot {
 
 	/// Scans key-value pairs in a key range at a specific timestamp
 	/// Only returns data visible to this snapshot (seq_num <= snapshot.seq_num)
-	pub(crate) fn scan_at_timestamp<'a, R: RangeBounds<Vec<u8>>>(
+	pub(crate) fn scan_at_version<'a, R: RangeBounds<Vec<u8>>>(
 		&'a self,
 		key_range: R,
 		timestamp: u64,
@@ -298,7 +298,7 @@ impl Snapshot {
 	/// Gets all versions of keys in a key range
 	/// Only returns data visible to this snapshot (seq_num <= snapshot.seq_num)
 	/// The limit currently is on the unique keys, not the total number of results
-	pub(crate) fn scan_all_timestamps<R: RangeBounds<Vec<u8>>>(
+	pub(crate) fn scan_all_versions<R: RangeBounds<Vec<u8>>>(
 		&self,
 		key_range: R,
 		limit: Option<usize>,
@@ -523,10 +523,10 @@ pub(crate) struct KeysAtTimestampIterator {
 }
 
 impl Iterator for KeysAtTimestampIterator {
-	type Item = Result<Vec<u8>>;
+	type Item = Vec<u8>;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		self.inner.next().map(|(internal_key, _)| Ok(internal_key.user_key.as_ref().to_vec()))
+		self.inner.next().map(|(internal_key, _)| internal_key.user_key.as_ref().to_vec())
 	}
 
 	fn size_hint(&self) -> (usize, Option<usize>) {
@@ -536,7 +536,7 @@ impl Iterator for KeysAtTimestampIterator {
 
 impl DoubleEndedIterator for KeysAtTimestampIterator {
 	fn next_back(&mut self) -> Option<Self::Item> {
-		self.inner.next_back().map(|(internal_key, _)| Ok(internal_key.user_key.as_ref().to_vec()))
+		self.inner.next_back().map(|(internal_key, _)| internal_key.user_key.as_ref().to_vec())
 	}
 }
 

--- a/src/sstable/mod.rs
+++ b/src/sstable/mod.rs
@@ -27,7 +27,8 @@ fn trailer_to_kind(trailer: u64) -> InternalKeyKind {
 		4 => InternalKeyKind::LogData,
 		5 => InternalKeyKind::RangeDelete,
 		6 => InternalKeyKind::Separator,
-		7 => InternalKeyKind::Max,
+		7 => InternalKeyKind::SetWithDelete,
+		24 => InternalKeyKind::Max,
 		_ => InternalKeyKind::Invalid,
 	}
 }
@@ -51,6 +52,11 @@ fn is_hard_delete_marker(kind: InternalKeyKind) -> bool {
 	matches!(kind, InternalKeyKind::Delete | InternalKeyKind::RangeDelete)
 }
 
+/// Checks if a key kind represents a SetWithDelete operation
+fn is_set_with_delete_kind(kind: InternalKeyKind) -> bool {
+	matches!(kind, InternalKeyKind::SetWithDelete)
+}
+
 /// Calculates the size of a key with the given user key length
 /// This centralizes the size calculation logic to avoid duplication
 fn calculate_key_size(user_key_len: usize, has_timestamp: bool) -> usize {
@@ -72,8 +78,9 @@ pub enum InternalKeyKind {
 	LogData = 4,
 	RangeDelete = 5,
 	Separator = 6,
-	Max = 7,
-	Invalid = 8,
+	SetWithDelete = 7, // Replaces previous key when versioning is enabled
+	Max = 24,          // Leaving space for other kinds
+	Invalid = 191,
 }
 
 impl From<u8> for InternalKeyKind {
@@ -143,6 +150,10 @@ impl InternalKey {
 
 	pub(crate) fn is_hard_delete_marker(&self) -> bool {
 		is_hard_delete_marker(self.kind())
+	}
+
+	pub(crate) fn is_set_with_delete(&self) -> bool {
+		is_set_with_delete_kind(self.kind())
 	}
 
 	/// Compares this key with another key using timestamp-based ordering

--- a/src/sstable/mod.rs
+++ b/src/sstable/mod.rs
@@ -27,7 +27,7 @@ fn trailer_to_kind(trailer: u64) -> InternalKeyKind {
 		4 => InternalKeyKind::LogData,
 		5 => InternalKeyKind::RangeDelete,
 		6 => InternalKeyKind::Separator,
-		7 => InternalKeyKind::SetWithDelete,
+		7 => InternalKeyKind::Replace,
 		24 => InternalKeyKind::Max,
 		_ => InternalKeyKind::Invalid,
 	}
@@ -52,9 +52,9 @@ fn is_hard_delete_marker(kind: InternalKeyKind) -> bool {
 	matches!(kind, InternalKeyKind::Delete | InternalKeyKind::RangeDelete)
 }
 
-/// Checks if a key kind represents a SetWithDelete operation
-fn is_set_with_delete_kind(kind: InternalKeyKind) -> bool {
-	matches!(kind, InternalKeyKind::SetWithDelete)
+/// Checks if a key kind represents a Replace operation
+fn is_replace_kind(kind: InternalKeyKind) -> bool {
+	matches!(kind, InternalKeyKind::Replace)
 }
 
 /// Calculates the size of a key with the given user key length
@@ -78,8 +78,8 @@ pub enum InternalKeyKind {
 	LogData = 4,
 	RangeDelete = 5,
 	Separator = 6,
-	SetWithDelete = 7, // Replaces previous key when versioning is enabled
-	Max = 24,          // Leaving space for other kinds
+	Replace = 7, // Replaces previous key when versioning is enabled
+	Max = 24,    // Leaving space for other kinds
 	Invalid = 191,
 }
 
@@ -152,8 +152,8 @@ impl InternalKey {
 		is_hard_delete_marker(self.kind())
 	}
 
-	pub(crate) fn is_set_with_delete(&self) -> bool {
-		is_set_with_delete_kind(self.kind())
+	pub(crate) fn is_replace(&self) -> bool {
+		is_replace_kind(self.kind())
 	}
 
 	/// Compares this key with another key using timestamp-based ordering

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -281,7 +281,7 @@ impl Transaction {
 		self.replace_with_options(key, value, &WriteOptions::default())
 	}
 
-	/// Sets a key-value pair with SetWithDelete and custom write options.
+	/// Sets a key-value pair with Replace and custom write options.
 	pub fn replace_with_options(
 		&mut self,
 		key: &[u8],
@@ -289,13 +289,8 @@ impl Transaction {
 		options: &WriteOptions,
 	) -> Result<()> {
 		let write_seqno = self.next_write_seqno();
-		let entry = Entry::new(
-			key,
-			Some(value),
-			InternalKeyKind::SetWithDelete,
-			self.savepoints,
-			write_seqno,
-		);
+		let entry =
+			Entry::new(key, Some(value), InternalKeyKind::Replace, self.savepoints, write_seqno);
 		self.write_with_options(entry, options)?;
 		Ok(())
 	}
@@ -3838,7 +3833,7 @@ mod tests {
 		async fn test_replace_basic() {
 			let (store, _tmp_dir) = create_tree();
 
-			// Test basic SetWithDelete functionality
+			// Test basic Replace functionality
 			let mut txn = store.begin().unwrap();
 			txn.replace(b"test_key", b"test_value").unwrap();
 			txn.commit().await.unwrap();
@@ -3848,7 +3843,7 @@ mod tests {
 			let result = txn.get(b"test_key").unwrap().unwrap();
 			assert_eq!(result.as_ref(), b"test_value");
 
-			// Test SetWithDelete with options
+			// Test Replace with options
 			let mut txn = store.begin().unwrap();
 			txn.replace_with_options(b"test_key2", b"test_value2", &WriteOptions::default())
 				.unwrap();
@@ -3877,7 +3872,7 @@ mod tests {
 			let result = txn.get(b"test_key").unwrap().unwrap();
 			assert_eq!(result.as_ref(), b"value_v5");
 
-			// Use SetWithDelete to replace all previous versions
+			// Use Replace to replace all previous versions
 			let mut txn = store.begin().unwrap();
 			txn.replace(b"test_key", b"replaced_value").unwrap();
 			txn.commit().await.unwrap();

--- a/src/vlog.rs
+++ b/src/vlog.rs
@@ -2523,7 +2523,7 @@ mod tests {
 		for (i, ts) in [1000, 2000, 3000, 4000].iter().enumerate() {
 			let value = format!("value_{}_large_data", i).repeat(50); // Large value to fill VLog
 			let mut tx = tree.begin().unwrap();
-			tx.set_at_ts(user_key, value.as_bytes(), *ts).unwrap();
+			tx.set_at_version(user_key, value.as_bytes(), *ts).unwrap();
 			tx.commit().await.unwrap();
 			tree.flush().unwrap(); // Force flush after each version
 		}
@@ -2531,7 +2531,7 @@ mod tests {
 		// Insert and delete a different key to create stale entries
 		{
 			let mut tx = tree.begin().unwrap();
-			tx.set_at_ts(b"other_key", &b"other_value_large_data".repeat(50), 5000).unwrap();
+			tx.set_at_version(b"other_key", &b"other_value_large_data".repeat(50), 5000).unwrap();
 			tx.commit().await.unwrap();
 			tree.flush().unwrap();
 
@@ -2544,7 +2544,7 @@ mod tests {
 
 		// Verify all versions exist using the public API
 		let tx = tree.begin().unwrap();
-		let scan_all = tx.scan_all_timestamps(user_key.to_vec()..=user_key.to_vec(), None).unwrap();
+		let scan_all = tx.scan_all_versions(user_key.to_vec()..=user_key.to_vec(), None).unwrap();
 		assert_eq!(scan_all.len(), 4, "Should have 4 versions before GC");
 
 		drop(tx);
@@ -2581,8 +2581,7 @@ mod tests {
 
 		// Verify that some versions were cleaned up using the public API
 		let tx = tree.begin().unwrap();
-		let scan_after =
-			tx.scan_all_timestamps(user_key.to_vec()..=user_key.to_vec(), None).unwrap();
+		let scan_after = tx.scan_all_versions(user_key.to_vec()..=user_key.to_vec(), None).unwrap();
 
 		// We should have at least some versions remaining
 		assert!(!scan_after.is_empty(), "Should have at least some versions remaining");
@@ -2599,32 +2598,32 @@ mod tests {
 
 		// Test specific timestamp queries to verify which versions were deleted
 		let scan_at_ts1 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 1000, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 1000, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();
 		let scan_at_ts2 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 2000, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 2000, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();
 		let scan_at_ts3 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 3000, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 3000, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();
 		let scan_at_ts4 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 4000, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 4000, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();
 		let scan_at_ts5 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6000, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 6000, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();
 		let scan_at_ts6 = tx
-			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6001, None)
+			.scan_at_version(user_key.to_vec()..=user_key.to_vec(), 6001, None)
 			.unwrap()
 			.collect::<std::result::Result<Vec<_>, _>>()
 			.unwrap();

--- a/src/vlog.rs
+++ b/src/vlog.rs
@@ -864,6 +864,8 @@ impl VLog {
 	}
 
 	/// Selects files based on discard statistics and compacts them
+	/// Attempts to compact the best candidate file (highest discard bytes that meets criteria)
+	/// Only processes one file per invocation
 	pub async fn garbage_collect(&self, commit_pipeline: Arc<CommitPipeline>) -> Result<Vec<u32>> {
 		// Try to set the gc_in_progress flag to true, if it's already true, return error
 		if self
@@ -880,72 +882,69 @@ impl VLog {
 			self.gc_in_progress.store(false, Ordering::SeqCst);
 		});
 
-		// Get the file with maximum discardable bytes
-		let (file_id, discard_bytes) = {
+		// Get all files with discardable bytes, sorted by discard bytes (descending)
+		let candidates = {
 			let discard_stats = self.discard_stats.lock().unwrap();
-			let result = discard_stats.max_discard();
+			discard_stats.get_gc_candidates()
+		};
 
-			match result {
-				Ok((file_id, discard_bytes)) => (file_id, discard_bytes),
-				Err(_) => {
-					return Ok(vec![]);
+		if candidates.is_empty() {
+			return Ok(vec![]);
+		}
+
+		// Get active writer ID once
+		let active_writer_id = self.active_writer_id.load(Ordering::SeqCst);
+
+		// Find the best candidate to compact (first one that meets all criteria)
+		let candidate_to_compact = candidates.into_iter().find(|(file_id, discard_bytes)| {
+			// Skip if no discard bytes
+			if *discard_bytes == 0 {
+				return false;
+			}
+
+			// Check if this file meets the discard ratio threshold
+			let (total_size, _, discard_ratio) = self.get_file_stats(*file_id);
+			if total_size == 0 || discard_ratio < self.gc_discard_ratio {
+				return false;
+			}
+
+			// Skip if this is the active writer
+			if *file_id == active_writer_id {
+				return false;
+			}
+
+			// Skip if file is already marked for deletion
+			if let Ok(files_to_delete) = self.files_to_be_deleted.read() {
+				if files_to_delete.contains(file_id) {
+					return false;
 				}
 			}
-		};
 
-		if discard_bytes == 0 {
-			// No files with discardable data
-			return Ok(vec![]);
-		}
+			true
+		});
 
-		// Check if this file meets the discard ratio threshold
-		let should_compact = {
-			let (total_size, _, discard_ratio) = self.get_file_stats(file_id);
+		// If we found a candidate, try to compact it
+		if let Some((file_id, _)) = candidate_to_compact {
+			let compacted = self.compact_vlog_file_safe(file_id, commit_pipeline.clone()).await?;
 
-			if total_size == 0 {
-				false
+			if compacted {
+				Ok(vec![file_id])
 			} else {
-				discard_ratio >= self.gc_discard_ratio
+				Ok(vec![])
 			}
-		};
-
-		if !should_compact {
-			return Ok(vec![]);
-		}
-
-		// Compact the selected file
-		let compacted = self.compact_vlog_file_safe(file_id, commit_pipeline.clone()).await?;
-
-		if compacted {
-			Ok(vec![file_id])
 		} else {
+			// No suitable candidate found
 			Ok(vec![])
 		}
 	}
 
 	/// Compacts a single value log file
+	/// Assumes caller has already checked that file is not active writer and not marked for deletion
 	async fn compact_vlog_file_safe(
 		&self,
 		file_id: u32,
 		commit_pipeline: Arc<CommitPipeline>,
 	) -> Result<bool> {
-		// Check if file is already marked for deletion
-		{
-			let files_to_delete = self.files_to_be_deleted.read()?;
-			if files_to_delete.contains(&file_id) {
-				return Err(Error::Other(format!(
-					"Value log file already marked for deletion fid: {file_id}"
-				)));
-			}
-		}
-
-		// Check if this is the currently open file for writing - we shouldn't compact/delete it
-		let active_writer_id = self.active_writer_id.load(Ordering::SeqCst);
-		if file_id == active_writer_id {
-			// Skip compacting the active file as it is currently open for writing
-			return Ok(false);
-		}
-
 		// Perform the actual compaction
 		let compacted = self.compact_vlog_file(file_id, commit_pipeline.clone()).await?;
 
@@ -1064,8 +1063,6 @@ impl VLog {
 				stale_seq_nums.push(internal_key.seq_num());
 				stale_internal_keys.push(internal_key.clone());
 			} else {
-				let internal_key = InternalKey::decode(&key);
-
 				// Add this entry to the batch to be rewritten with the correct operation type
 				// This preserves the original operation (Set, Delete, Merge, etc.)
 				// This will cause the value to be written to the active VLog file
@@ -1557,7 +1554,8 @@ mod tests {
 		// Test another file
 		stats.update(2, 300); // Higher discard
 
-		let (max_file, max_discard) = stats.max_discard().unwrap();
+		let candidates = stats.get_gc_candidates();
+		let (max_file, max_discard) = candidates[0];
 		assert_eq!(max_file, 2);
 		assert_eq!(max_discard, 300);
 	}
@@ -1583,7 +1581,8 @@ mod tests {
 		assert_eq!(discard_bytes_2, 200);
 
 		// Test max discard selection (used by conservative GC)
-		let (max_file, max_discard) = stats.max_discard().unwrap();
+		let candidates = stats.get_gc_candidates();
+		let (max_file, max_discard) = candidates[0];
 		assert_eq!(max_file, 1, "File 1 should have maximum discard bytes");
 		assert_eq!(max_discard, 600);
 	}

--- a/src/vlog.rs
+++ b/src/vlog.rs
@@ -939,7 +939,6 @@ impl VLog {
 	}
 
 	/// Compacts a single value log file
-	/// Assumes caller has already checked that file is not active writer and not marked for deletion
 	async fn compact_vlog_file_safe(
 		&self,
 		file_id: u32,

--- a/src/vlog.rs
+++ b/src/vlog.rs
@@ -2600,18 +2600,36 @@ mod tests {
 		}
 
 		// Test specific timestamp queries to verify which versions were deleted
-		let scan_at_ts1 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 1000, None).unwrap();
-		let scan_at_ts2 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 2000, None).unwrap();
-		let scan_at_ts3 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 3000, None).unwrap();
-		let scan_at_ts4 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 4000, None).unwrap();
-		let scan_at_ts5 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6000, None).unwrap();
-		let scan_at_ts6 =
-			tx.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6001, None).unwrap();
+		let scan_at_ts1 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 1000, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
+		let scan_at_ts2 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 2000, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
+		let scan_at_ts3 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 3000, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
+		let scan_at_ts4 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 4000, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
+		let scan_at_ts5 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6000, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
+		let scan_at_ts6 = tx
+			.scan_at_timestamp(user_key.to_vec()..=user_key.to_vec(), 6001, None)
+			.unwrap()
+			.collect::<std::result::Result<Vec<_>, _>>()
+			.unwrap();
 
 		// The key insight: VLog GC only processes files with high discard ratios
 		// Files 0, 1, 2 had high discard ratios (0.97) and were processed


### PR DESCRIPTION
## Key Changes

### New Replace API
- **Added `replace()` method** for transactions to replace existing values

### In-memory support
- **Removed in-memory option**

### Versioning API Improvements
- **Renamed `timestamp` → `version`** in APIs for better clarity
- **Made versioned APIs double-ended**: `keys_at_version()` and `scan_at_version()` now support reverse iteration
- **Enhanced range scan results** to return `Arc` references than clones

### Iterator Enhancements
- **Added double-ended iterator tests** for `TransactionRangeIterator`
- **Fixed compaction iterator bug** to properly preserve non-stale keys
- **Added extensive Replace operation tests** covering multiple scenarios:
  - Multiple Replace operations (only latest preserved)
  - SET → Replace → SET sequences
  - Replace → Delete sequences
  - Both with/without versioning enabled

### Bug Fixes
- **Fixed VLog GC** to pick other candidates when current can't be compacted
