### PR TITLE
feat(wal): add .wal file extension to WAL segments

### DIFF
--- a/src/wal/cleanup.rs
+++ b/src/wal/cleanup.rs
@@ -22,8 +22,8 @@ pub(crate) fn cleanup_old_segments(wal_dir: &Path) -> Result<usize> {
 		return Ok(0);
 	}
 
-	// Get range of segment IDs
-	let (first, last) = match get_segment_range(wal_dir, None) {
+	// Get range of segment IDs (looking for .wal files)
+	let (first, last) = match get_segment_range(wal_dir, Some("wal")) {
 		Ok(range) => range,
 		Err(_) => return Ok(0), // No segments to clean
 	};
@@ -33,14 +33,14 @@ pub(crate) fn cleanup_old_segments(wal_dir: &Path) -> Result<usize> {
 		return Ok(0);
 	}
 
-	// List all segment IDs
-	let segment_ids = list_segment_ids(wal_dir, None)?;
+	// List all segment IDs with .wal extension
+	let segment_ids = list_segment_ids(wal_dir, Some("wal"))?;
 	let mut removed_count = 0;
 
 	// Remove all segments except the latest one
 	for segment_id in segment_ids {
 		if segment_id < last {
-			let segment_path = wal_dir.join(format!("{segment_id:020}"));
+			let segment_path = wal_dir.join(format!("{segment_id:020}.wal"));
 
 			match fs::remove_file(&segment_path) {
 				Ok(_) => {

--- a/src/wal/reader.rs
+++ b/src/wal/reader.rs
@@ -280,7 +280,7 @@ mod tests {
 		assert!(segment2.close().is_ok());
 		assert!(segment3.close().is_ok());
 
-		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 			.expect("should read segments");
 
 		let mut reader = Reader::new(MultiSegmentReader::new(sr).expect("should create"));
@@ -323,7 +323,7 @@ mod tests {
 		let mut segment1 = create_test_segment_with_data(&temp_dir, 4);
 		assert!(segment1.close().is_ok());
 
-		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 			.expect("should read segments");
 
 		let mut reader = Reader::new(MultiSegmentReader::new(sr).expect("should create"));
@@ -350,7 +350,7 @@ mod tests {
 		assert!(segment2.close().is_ok());
 		assert!(segment3.close().is_ok());
 
-		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 			.expect("should read segments");
 
 		let mut reader = Reader::new(MultiSegmentReader::new(sr).expect("should create"));
@@ -386,7 +386,7 @@ mod tests {
 
 		a.sync().expect("should sync");
 
-		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+		let sr = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 			.expect("should read segments");
 
 		let mut reader = Reader::new(MultiSegmentReader::new(sr).expect("should create"));

--- a/src/wal/tests.rs
+++ b/src/wal/tests.rs
@@ -43,7 +43,7 @@ fn test_cleanup_old_segments() {
 	}
 
 	// Get segment IDs and verify we have at least 5
-	let segment_ids_before = list_segment_ids(temp_dir.path(), None).unwrap();
+	let segment_ids_before = list_segment_ids(temp_dir.path(), Some("wal")).unwrap();
 	assert!(
 		segment_ids_before.len() >= 5,
 		"Expected at least 5 segments, got {}",
@@ -57,7 +57,7 @@ fn test_cleanup_old_segments() {
 	assert!(removed_count >= 4, "Expected at least 4 segments to be removed, got {removed_count}");
 
 	// Verify only the latest segment remains
-	let remaining_segment_ids = list_segment_ids(temp_dir.path(), None).unwrap();
+	let remaining_segment_ids = list_segment_ids(temp_dir.path(), Some("wal")).unwrap();
 
 	// Should have exactly 1 segment remaining
 	assert_eq!(
@@ -118,7 +118,7 @@ fn test_wal_replay_latest_segment_only() {
 	drop(wal);
 
 	// Get segment IDs and verify we have at least 3
-	let segment_ids = list_segment_ids(temp_dir.path(), None).unwrap();
+	let segment_ids = list_segment_ids(temp_dir.path(), Some("wal")).unwrap();
 	assert!(segment_ids.len() >= 3, "Expected at least 3 segments, got {}", segment_ids.len());
 
 	// Create a memtable for recovery
@@ -156,7 +156,7 @@ fn test_wal_with_zero_padding_eof_handling() {
 	segment.close().expect("should close segment");
 
 	// Now try to read from the segment using the Reader
-	let segments = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+	let segments = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 		.expect("should read segments");
 
 	let multi_reader =
@@ -212,7 +212,7 @@ fn test_empty_wal_segment() {
 	drop(segment);
 
 	// Try to read from the empty segment
-	let segments = SegmentRef::read_segments_from_directory(temp_dir.path(), None)
+	let segments = SegmentRef::read_segments_from_directory(temp_dir.path(), Some("wal"))
 		.expect("should read segments");
 
 	let multi_reader =


### PR DESCRIPTION
- Change default WAL file extension from none to '.wal'
- Update all WAL file operations to use .wal extension
- Update repair mechanism to work with .wal files (creates .wal.repair temp files)
- Update cleanup and recovery logic to filter by .wal extension
- Fix all WAL tests to expect .wal extension

This ensures consistency with other file types (SSTable uses .sst, VLog uses .vlog, etc.) and makes it easier to identify WAL files in the database directory.

The repair mechanism now creates .wal.repair files instead of .repair files, which properly differentiates repair files while maintaining the .wal namespace.