### PR TITLE
fix(vlog): improve error handling in VLog operations

### DIFF
--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -648,7 +648,7 @@ impl Core {
 		// Stop VLog GC manager if it exists
 		let vlog_gc_manager = self.vlog_gc_manager.lock().unwrap().take();
 		if let Some(vlog_gc_manager) = vlog_gc_manager {
-			vlog_gc_manager.stop().await;
+			vlog_gc_manager.stop().await?;
 		}
 
 		// Step 3: Flush the active memtable only if it exceeds the configured size


### PR DESCRIPTION
- Change VLogGCManager::stop() to return Result for proper error propagation
- Return errors instead of logging and continuing in delete list checks
- Properly handle VLog close errors during GC manager shutdown
- Change log level from warn to error for delete list check failures

This ensures that VLog errors are properly propagated up the call stack instead of being silently ignored, improving error visibility and debugging.