### PR TITLE
Use LSM tree itself as delete list

### DIFF
--- a/src/bplustree/tree.rs
+++ b/src/bplustree/tree.rs
@@ -902,13 +902,6 @@ impl BPlusTree<File> {
 	}
 }
 
-pub fn new_disk_tree<P: AsRef<Path>>(
-	path: P,
-	compare: Arc<dyn Comparator>,
-) -> Result<DiskBPlusTree> {
-	DiskBPlusTree::disk(path, compare)
-}
-
 impl<F: VfsFile> BPlusTree<F> {
 	pub fn with_file(file: F, compare: Arc<dyn Comparator>) -> Result<Self> {
 		let storage_size = file.size()?;
@@ -1327,6 +1320,7 @@ impl<F: VfsFile> BPlusTree<F> {
 		}
 	}
 
+	#[allow(unused)]
 	pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
 		self.get_internal(self.header.root_offset, key)
 	}

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -208,6 +208,49 @@ impl CommitPipeline {
 		}
 	}
 
+	pub fn sync_commit(&self, mut batch: Batch, sync_wal: bool) -> Result<()> {
+		if self.shutdown.load(Ordering::Acquire) {
+			return Err(Error::PipelineStall);
+		}
+
+		if batch.is_empty() {
+			return Ok(());
+		}
+
+		// Acquire write lock to ensure serialization
+		let _guard = self.write_mutex.lock().unwrap();
+
+		// Assign sequence number
+		let count = batch.count() as u64;
+		let seq_num = self.log_seq_num.fetch_add(count, Ordering::SeqCst);
+
+		// Set the starting sequence number in the batch
+		batch.set_starting_seq_num(seq_num);
+
+		// Write to WAL and get processed batch
+		let processed_batch = self.env.write(&batch, seq_num, sync_wal)?;
+
+		// Apply processed batch to memtable
+		self.env.apply(&processed_batch)?;
+
+		// Update visible sequence number
+		let new_visible = seq_num + count - 1;
+		let mut current = self.visible_seq_num.load(Ordering::Acquire);
+		while new_visible > current {
+			match self.visible_seq_num.compare_exchange_weak(
+				current,
+				new_visible,
+				Ordering::Release,
+				Ordering::Relaxed,
+			) {
+				Ok(_) => break,
+				Err(actual) => current = actual,
+			}
+		}
+
+		Ok(())
+	}
+
 	pub(crate) async fn commit(&self, mut batch: Batch, sync: bool) -> Result<()> {
 		if self.shutdown.load(Ordering::Acquire) {
 			return Err(Error::PipelineStall);
@@ -502,6 +545,268 @@ mod tests {
 		assert_eq!(pipeline.get_visible_seq_num(), 5);
 
 		// Shutdown the pipeline
+		pipeline.shutdown();
+	}
+
+	// ===== Sync Commit Tests =====
+
+	#[test]
+	fn test_sync_commit_single() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+
+		let mut batch = Batch::new(0);
+		batch.add_record(InternalKeyKind::Set, b"key1", Some(b"value1"), 0).unwrap();
+
+		let result = pipeline.sync_commit(batch, false);
+		assert!(result.is_ok(), "Sync commit failed: {result:?}");
+
+		let visible = pipeline.get_visible_seq_num();
+		assert_eq!(visible, 1, "Expected visible=1 after sync commit");
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_multiple_sequential() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+
+		// Test multiple sequential sync commits
+		for i in 0..5 {
+			let mut batch = Batch::new(0);
+			batch
+				.add_record(
+					InternalKeyKind::Set,
+					&format!("key{i}").into_bytes(),
+					Some(&[1, 2, 3]),
+					i as u64,
+				)
+				.unwrap();
+
+			let result = pipeline.sync_commit(batch, false);
+			assert!(result.is_ok(), "Sync commit {i} failed: {result:?}");
+		}
+
+		// Verify final sequence number
+		assert_eq!(pipeline.get_visible_seq_num(), 5);
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_empty_batch() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+
+		let batch = Batch::new(0);
+		let result = pipeline.sync_commit(batch, false);
+		assert!(result.is_ok(), "Empty batch sync commit should succeed");
+
+		// Sequence number should not change for empty batch
+		assert_eq!(pipeline.get_visible_seq_num(), 0);
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_with_sync_wal() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+
+		let mut batch = Batch::new(0);
+		batch.add_record(InternalKeyKind::Set, b"key1", Some(b"value1"), 0).unwrap();
+
+		let result = pipeline.sync_commit(batch, true); // sync_wal = true
+		assert!(result.is_ok(), "Sync commit with sync_wal failed: {result:?}");
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_sequence_number_consistency() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+
+		// Set initial sequence number
+		pipeline.set_seq_num(100);
+
+		let mut batch1 = Batch::new(0);
+		batch1.add_record(InternalKeyKind::Set, b"key1", Some(b"value1"), 0).unwrap();
+
+		let mut batch2 = Batch::new(0);
+		batch2.add_record(InternalKeyKind::Set, b"key2", Some(b"value2"), 1).unwrap();
+		batch2.add_record(InternalKeyKind::Set, b"key3", Some(b"value3"), 2).unwrap();
+
+		// Commit first batch
+		pipeline.sync_commit(batch1, false).unwrap();
+		assert_eq!(pipeline.get_visible_seq_num(), 101); // 100 + 1 - 1
+
+		// Commit second batch (2 records)
+		pipeline.sync_commit(batch2, false).unwrap();
+		assert_eq!(pipeline.get_visible_seq_num(), 103); // 101 + 2 - 1
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_after_shutdown() {
+		let pipeline = CommitPipeline::new(Arc::new(MockEnv));
+		pipeline.shutdown();
+
+		let mut batch = Batch::new(0);
+		batch.add_record(InternalKeyKind::Set, b"key1", Some(b"value1"), 0).unwrap();
+
+		let result = pipeline.sync_commit(batch, false);
+		assert!(result.is_err(), "Sync commit after shutdown should fail");
+	}
+
+	// Mock environment that tracks calls for testing
+	struct TrackingMockEnv {
+		write_calls: std::sync::atomic::AtomicU64,
+		apply_calls: std::sync::atomic::AtomicU64,
+		last_sync_wal: std::sync::atomic::AtomicBool,
+	}
+
+	impl TrackingMockEnv {
+		fn new() -> Self {
+			Self {
+				write_calls: std::sync::atomic::AtomicU64::new(0),
+				apply_calls: std::sync::atomic::AtomicU64::new(0),
+				last_sync_wal: std::sync::atomic::AtomicBool::new(false),
+			}
+		}
+
+		fn write_calls(&self) -> u64 {
+			self.write_calls.load(std::sync::atomic::Ordering::Relaxed)
+		}
+
+		fn apply_calls(&self) -> u64 {
+			self.apply_calls.load(std::sync::atomic::Ordering::Relaxed)
+		}
+
+		fn last_sync_wal(&self) -> bool {
+			self.last_sync_wal.load(std::sync::atomic::Ordering::Relaxed)
+		}
+	}
+
+	impl CommitEnv for TrackingMockEnv {
+		fn write(&self, batch: &Batch, _seq_num: u64, sync_wal: bool) -> Result<Batch> {
+			self.write_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+			self.last_sync_wal.store(sync_wal, std::sync::atomic::Ordering::Relaxed);
+
+			// Create a copy of the batch for testing (like MockEnv does)
+			let mut new_batch = Batch::new(_seq_num);
+			for entry in batch.entries() {
+				new_batch.add_record(
+					entry.kind,
+					&entry.key,
+					entry.value.as_deref(),
+					entry.timestamp,
+				)?;
+			}
+			Ok(new_batch)
+		}
+
+		fn apply(&self, _batch: &Batch) -> Result<()> {
+			self.apply_calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn test_sync_commit_calls_write_and_apply() {
+		let env = Arc::new(TrackingMockEnv::new());
+		let pipeline = CommitPipeline::new(env.clone());
+
+		let mut batch = Batch::new(0);
+		batch.add_record(InternalKeyKind::Set, b"key1", Some(b"value1"), 0).unwrap();
+
+		// Verify initial state
+		assert_eq!(env.write_calls(), 0);
+		assert_eq!(env.apply_calls(), 0);
+
+		// Perform sync commit
+		pipeline.sync_commit(batch, true).unwrap();
+
+		// Verify both write and apply were called
+		assert_eq!(env.write_calls(), 1);
+		assert_eq!(env.apply_calls(), 1);
+		assert!(env.last_sync_wal());
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_multiple_batches_tracking() {
+		let env = Arc::new(TrackingMockEnv::new());
+		let pipeline = CommitPipeline::new(env.clone());
+
+		// Commit multiple batches
+		for i in 0..3 {
+			let mut batch = Batch::new(0);
+			batch
+				.add_record(
+					InternalKeyKind::Set,
+					&format!("key{i}").into_bytes(),
+					Some(&[1, 2, 3]),
+					i as u64,
+				)
+				.unwrap();
+
+			pipeline.sync_commit(batch, i % 2 == 0).unwrap(); // Alternate sync_wal
+		}
+
+		// Verify correct number of calls
+		assert_eq!(env.write_calls(), 3);
+		assert_eq!(env.apply_calls(), 3);
+
+		pipeline.shutdown();
+	}
+
+	#[test]
+	fn test_sync_commit_concurrent_access() {
+		let env = Arc::new(TrackingMockEnv::new());
+		let pipeline_clone = CommitPipeline::new(env.clone());
+		let pipeline = Arc::new(pipeline_clone);
+
+		// Test concurrent access to sync_commit
+		let mut handles = vec![];
+		let num_threads = 8;
+		let batches_per_thread = 5;
+
+		for thread_id in 0..num_threads {
+			let pipeline = pipeline.clone();
+			let _env = env.clone();
+
+			let handle = std::thread::spawn(move || {
+				for batch_id in 0..batches_per_thread {
+					let mut batch = Batch::new(0);
+					batch
+						.add_record(
+							InternalKeyKind::Set,
+							&format!("thread_{thread_id}_batch_{batch_id}").into_bytes(),
+							Some(&[thread_id as u8, batch_id as u8]),
+							batch_id,
+						)
+						.unwrap();
+
+					// This should be safe even under concurrency due to write_mutex
+					pipeline.sync_commit(batch, false).unwrap();
+				}
+			});
+			handles.push(handle);
+		}
+
+		// Wait for all threads to complete
+		for handle in handles {
+			handle.join().unwrap();
+		}
+
+		// Verify all operations were processed
+		let expected_calls = num_threads * batches_per_thread;
+		assert_eq!(env.write_calls(), expected_calls);
+		assert_eq!(env.apply_calls(), expected_calls);
+
+		// Verify sequence numbers are continuous and correct
+		let final_visible = pipeline.get_visible_seq_num();
+		assert_eq!(final_visible, expected_calls);
+
 		pipeline.shutdown();
 	}
 }


### PR DESCRIPTION
The LSM Tree itself can be used as the delete list, instead of the bplustree. This allows stable usage of the entire lsm process, and compaction is not impacted by bplustree performance, which can be improved with time, and then later replaced once more stable https://github.com/surrealdb/surrealkv/pull/232