### PR TITLE
Improve insert/delete performance in bplustree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Temporary Items
 **/*.rs.bk
 *.db
 *.sw?
+*.gz
 
 # -----------------------------------
 # Folders
@@ -54,3 +55,6 @@ test_data/
 # Added by cargo
 
 /target
+/.cursor
+
+


### PR DESCRIPTION
This PR fixes the redundant double calls into the cache before reading nodes, and makes nodetype arc internally to avoid copying of data