### PR TITLE
Remove vlog cache

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,55 +8,42 @@ use crate::Value;
 
 pub type CacheID = u64;
 
+/// Kind constants for differentiating cache entry types
+const KIND_DATA: u8 = 0;
+const KIND_INDEX: u8 = 1;
+const KIND_VLOG: u8 = 2;
+
 #[derive(Clone)]
-pub enum Item {
+pub(crate) enum Item {
 	Data(Arc<Block>),
 	Index(Arc<Block>),
+	VLog(Value),
 }
 
-// VLog cache key: (file_id, offset)
-#[derive(Eq, std::hash::Hash, PartialEq)]
-pub(crate) struct VLogCacheKey {
-	pub file_id: u32,
-	pub offset: u64,
-}
-
-impl From<(u32, u64)> for VLogCacheKey {
-	fn from(value: (u32, u64)) -> Self {
-		Self {
-			file_id: value.0,
-			offset: value.1,
-		}
-	}
-}
-
-impl Equivalent<VLogCacheKey> for (u32, &u64) {
-	/// Checks if a tuple `(u32, &u64)` is equivalent to a `VLogCacheKey`.
-	fn equivalent(&self, key: &VLogCacheKey) -> bool {
-		self.0 == key.file_id && *self.1 == key.offset
-	}
-}
-
-// (Type (disk or index), SSTable ID, Block offset)
+/// Cache key with kind-based differentiation.
+/// - kind: Differentiates between data blocks, index blocks, and VLog values
+/// - id: table_id for blocks, file_id for VLog
+/// - offset: Block or value offset within the file
 #[derive(Eq, std::hash::Hash, PartialEq)]
 pub(crate) struct CacheKey {
-	table_id: u64,
+	kind: u8,
+	id: u64,
 	offset: u64,
 }
 
-impl From<(u64, u64)> for CacheKey {
-	fn from(value: (u64, u64)) -> Self {
+impl From<(u8, u64, u64)> for CacheKey {
+	fn from((kind, id, offset): (u8, u64, u64)) -> Self {
 		Self {
-			table_id: value.0,
-			offset: value.1,
+			kind,
+			id,
+			offset,
 		}
 	}
 }
 
-impl Equivalent<CacheKey> for (u64, &u64) {
-	/// Checks if a tuple `(u64, &u64)` is equivalent to a `CacheKey`.
+impl Equivalent<CacheKey> for (u8, u64, &u64) {
 	fn equivalent(&self, key: &CacheKey) -> bool {
-		self.0 == key.table_id && *self.1 == key.offset
+		self.0 == key.kind && self.1 == key.id && *self.2 == key.offset
 	}
 }
 
@@ -64,42 +51,12 @@ impl Equivalent<CacheKey> for (u64, &u64) {
 struct BlockWeighter;
 
 impl Weighter<CacheKey, Item> for BlockWeighter {
-	fn weight(&self, _: &CacheKey, block: &Item) -> u64 {
-		match block {
+	fn weight(&self, _: &CacheKey, item: &Item) -> u64 {
+		match item {
 			Item::Data(block) => block.size() as u64,
 			Item::Index(block) => block.size() as u64,
+			Item::VLog(value) => value.len() as u64,
 		}
-	}
-}
-
-#[derive(Clone)]
-struct VLogValueWeighter;
-
-impl Weighter<VLogCacheKey, Value> for VLogValueWeighter {
-	fn weight(&self, _: &VLogCacheKey, value: &Value) -> u64 {
-		value.len() as u64
-	}
-}
-
-/// Dedicated cache for VLog values
-pub(crate) struct VLogCache {
-	data: QCache<VLogCacheKey, Value, VLogValueWeighter>,
-}
-
-impl VLogCache {
-	pub(crate) fn with_capacity_bytes(bytes: u64) -> Self {
-		Self {
-			data: QCache::with_weighter(10_000, bytes, VLogValueWeighter),
-		}
-	}
-
-	pub(crate) fn insert(&self, file_id: u32, offset: u64, value: Value) {
-		self.data.insert((file_id, offset).into(), value);
-	}
-
-	pub(crate) fn get(&self, file_id: u32, offset: u64) -> Option<Value> {
-		let key = (file_id, &offset);
-		self.data.get(&key)
 	}
 }
 
@@ -115,6 +72,10 @@ pub(crate) struct BlockCache {
 	index_hits: AtomicU64,
 	#[cfg(test)]
 	index_misses: AtomicU64,
+	#[cfg(test)]
+	vlog_hits: AtomicU64,
+	#[cfg(test)]
+	vlog_misses: AtomicU64,
 }
 
 impl BlockCache {
@@ -130,15 +91,31 @@ impl BlockCache {
 			index_hits: AtomicU64::new(0),
 			#[cfg(test)]
 			index_misses: AtomicU64::new(0),
+			#[cfg(test)]
+			vlog_hits: AtomicU64::new(0),
+			#[cfg(test)]
+			vlog_misses: AtomicU64::new(0),
 		}
 	}
 
-	pub(crate) fn insert(&self, table_id: u64, offset: u64, value: Item) {
-		self.data.insert((table_id, offset).into(), value);
+	/// Inserts a data block into the cache.
+	pub(crate) fn insert_data_block(&self, table_id: u64, offset: u64, block: Arc<Block>) {
+		self.data.insert((KIND_DATA, table_id, offset).into(), Item::Data(block));
 	}
 
+	/// Inserts an index block into the cache.
+	pub(crate) fn insert_index_block(&self, table_id: u64, offset: u64, block: Arc<Block>) {
+		self.data.insert((KIND_INDEX, table_id, offset).into(), Item::Index(block));
+	}
+
+	/// Inserts a VLog value into the cache.
+	pub(crate) fn insert_vlog(&self, file_id: u32, offset: u64, value: Value) {
+		self.data.insert((KIND_VLOG, file_id as u64, offset).into(), Item::VLog(value));
+	}
+
+	/// Retrieves a data block from the cache.
 	pub(crate) fn get_data_block(&self, table_id: u64, offset: u64) -> Option<Arc<Block>> {
-		let key = (table_id, &offset);
+		let key = (KIND_DATA, table_id, &offset);
 		let item = self.data.get(&key);
 
 		#[cfg(test)]
@@ -156,8 +133,9 @@ impl BlockCache {
 		}
 	}
 
+	/// Retrieves an index block from the cache.
 	pub(crate) fn get_index_block(&self, table_id: u64, offset: u64) -> Option<Arc<Block>> {
-		let key = (table_id, &offset);
+		let key = (KIND_INDEX, table_id, &offset);
 		let item = self.data.get(&key);
 
 		#[cfg(test)]
@@ -175,6 +153,26 @@ impl BlockCache {
 		}
 	}
 
+	/// Retrieves a VLog value from the cache.
+	pub(crate) fn get_vlog(&self, file_id: u32, offset: u64) -> Option<Value> {
+		let key = (KIND_VLOG, file_id as u64, &offset);
+		let item = self.data.get(&key);
+
+		#[cfg(test)]
+		{
+			if item.is_some() {
+				self.vlog_hits.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+			} else {
+				self.vlog_misses.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+			}
+		}
+
+		match item.as_ref()? {
+			Item::VLog(value) => Some(value.clone()),
+			_ => None,
+		}
+	}
+
 	pub(crate) fn new_cache_id(&self) -> CacheID {
 		let id = self.id.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 		id + 1
@@ -188,6 +186,8 @@ impl BlockCache {
 			data_misses: self.data_misses.load(std::sync::atomic::Ordering::Relaxed),
 			index_hits: self.index_hits.load(std::sync::atomic::Ordering::Relaxed),
 			index_misses: self.index_misses.load(std::sync::atomic::Ordering::Relaxed),
+			vlog_hits: self.vlog_hits.load(std::sync::atomic::Ordering::Relaxed),
+			vlog_misses: self.vlog_misses.load(std::sync::atomic::Ordering::Relaxed),
 		}
 	}
 
@@ -198,6 +198,8 @@ impl BlockCache {
 		self.data_misses.store(0, std::sync::atomic::Ordering::Relaxed);
 		self.index_hits.store(0, std::sync::atomic::Ordering::Relaxed);
 		self.index_misses.store(0, std::sync::atomic::Ordering::Relaxed);
+		self.vlog_hits.store(0, std::sync::atomic::Ordering::Relaxed);
+		self.vlog_misses.store(0, std::sync::atomic::Ordering::Relaxed);
 	}
 }
 
@@ -209,16 +211,18 @@ pub(crate) struct CacheStats {
 	pub data_misses: u64,
 	pub index_hits: u64,
 	pub index_misses: u64,
+	pub vlog_hits: u64,
+	pub vlog_misses: u64,
 }
 
 #[cfg(test)]
 impl CacheStats {
 	pub fn total_hits(&self) -> u64 {
-		self.data_hits + self.index_hits
+		self.data_hits + self.index_hits + self.vlog_hits
 	}
 
 	pub fn total_misses(&self) -> u64 {
-		self.data_misses + self.index_misses
+		self.data_misses + self.index_misses + self.vlog_misses
 	}
 
 	pub fn total_accesses(&self) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,7 @@ pub struct Options {
 	pub filter_policy: Option<Arc<dyn FilterPolicy>>,
 	pub comparator: Arc<dyn Comparator>,
 	pub compression: CompressionType,
-	block_cache: Arc<cache::BlockCache>,
-	vlog_cache: Arc<cache::VLogCache>,
+	pub(crate) block_cache: Arc<cache::BlockCache>,
 	pub path: PathBuf,
 	pub level_count: u8,
 	pub max_memtable_size: usize,
@@ -228,8 +227,7 @@ impl Default for Options {
 			comparator: Arc::new(crate::BytewiseComparator {}),
 			compression: CompressionType::None,
 			filter_policy: Some(Arc::new(bf)),
-			block_cache: Arc::new(cache::BlockCache::with_capacity_bytes(1 << 20)),
-			vlog_cache: Arc::new(cache::VLogCache::with_capacity_bytes(1 << 20)),
+			block_cache: Arc::new(cache::BlockCache::with_capacity_bytes(1 << 20)), // 1MB cache
 			path: PathBuf::from(""),
 			level_count: 6,
 			max_memtable_size: 100 * 1024 * 1024,  // 100 MB
@@ -292,14 +290,9 @@ impl Options {
 		self
 	}
 
-	// Method to set block_cache capacity
+	/// Sets the unified block cache capacity (includes data blocks, index blocks, and VLog values)
 	pub fn with_block_cache_capacity(mut self, capacity_bytes: u64) -> Self {
 		self.block_cache = Arc::new(cache::BlockCache::with_capacity_bytes(capacity_bytes));
-		self
-	}
-
-	pub fn with_vlog_cache_capacity(mut self, capacity_bytes: u64) -> Self {
-		self.vlog_cache = Arc::new(cache::VLogCache::with_capacity_bytes(capacity_bytes));
 		self
 	}
 

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1357,15 +1357,9 @@ impl TreeBuilder {
 		self
 	}
 
-	/// Sets the block cache capacity.
+	/// Sets the unified block cache capacity (includes data blocks, index blocks, and VLog values).
 	pub fn with_block_cache_capacity(mut self, capacity_bytes: u64) -> Self {
 		self.opts = self.opts.with_block_cache_capacity(capacity_bytes);
-		self
-	}
-
-	/// Sets the VLog cache capacity.
-	pub fn with_vlog_cache_capacity(mut self, capacity_bytes: u64) -> Self {
-		self.opts = self.opts.with_vlog_cache_capacity(capacity_bytes);
 		self
 	}
 

--- a/src/sstable/index_block.rs
+++ b/src/sstable/index_block.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use std::sync::Arc;
 
 use crate::{
-	cache::Item,
 	error::{Error, Result},
 	sstable::{
 		block::{Block, BlockData, BlockHandle, BlockWriter},
@@ -205,7 +204,7 @@ impl TopLevelIndex {
 		let block_data =
 			read_table_block(self.opts.clone(), self.file.clone(), &block_handle.handle)?;
 		let block = Arc::new(block_data);
-		self.opts.block_cache.insert(self.id, block_handle.offset(), Item::Index(block.clone()));
+		self.opts.block_cache.insert_index_block(self.id, block_handle.offset(), block.clone());
 
 		Ok(block)
 	}

--- a/src/sstable/table.rs
+++ b/src/sstable/table.rs
@@ -9,7 +9,7 @@ use integer_encoding::{FixedInt, FixedIntWriter};
 use snap::raw::max_compress_len;
 
 use crate::{
-	cache::{self, Item},
+	cache,
 	error::{Error, Result},
 	sstable::{
 		block::{Block, BlockData, BlockHandle, BlockIterator, BlockWriter},
@@ -721,11 +721,7 @@ impl Table {
 		let b = read_table_block(self.opts.clone(), self.file.clone(), location)?;
 		let b = Arc::new(b);
 
-		self.opts.block_cache.insert(
-			self.cache_id,
-			location.offset() as u64,
-			Item::Data(b.clone()),
-		);
+		self.opts.block_cache.insert_data_block(self.cache_id, location.offset() as u64, b.clone());
 
 		Ok(b)
 	}


### PR DESCRIPTION
Plan is to have a single unified cache, because setting both from a user's perspective might be confusing as vlog cache requires more cache than keys stored in lsm index, and users think the other way round