### PR TITLE
Add `clone_on_ref_ptr` to the clippy lints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ assigning_clones = "warn"
 # https://rust-lang.github.io/rust-clippy/master/#bool_assert_comparison
 bool_assert_comparison = "allow"
 
+# Checks for usage of .clone() on a ref-counted pointer, (Rc, Arc, rc::Weak, or sync::Weak),
+# and suggests calling Clone via unified function syntax instead (e.g., Rc::clone(foo)).
+# https://rust-lang.github.io/rust-clippy/master/#clone_on_ref_ptr
+clone_on_ref_ptr = "warn"
+
 # Checks for the usage of `as _` conversion using inferred type.
 # https://rust-lang.github.io/rust-clippy/master/#cloned_instead_of_copied
 cloned_instead_of_copied = "warn"

--- a/src/bplustree/tree.rs
+++ b/src/bplustree/tree.rs
@@ -2184,7 +2184,7 @@ impl<F: VfsFile> BPlusTree<F> {
 				if let NodeType::Internal(left_node) = left_arc.as_ref() {
 					// Check if left sibling has enough to redistribute and is not in underflow
 					if !left_node.is_underflow() {
-						let mut left_node_mut = self.extract_internal_mut(left_arc.clone());
+						let mut left_node_mut = self.extract_internal_mut(Arc::clone(left_arc));
 						let mut right_node_mut =
 							self.read_internal_node(parent.children[child_idx])?;
 						self.redistribute_internal_from_left(
@@ -2201,7 +2201,7 @@ impl<F: VfsFile> BPlusTree<F> {
 				if let NodeType::Leaf(left_node) = left_arc.as_ref() {
 					// Check if left sibling has enough to redistribute and is not in underflow
 					if !left_node.is_underflow() {
-						let mut left_node_mut = self.extract_leaf_mut(left_arc.clone());
+						let mut left_node_mut = self.extract_leaf_mut(Arc::clone(left_arc));
 						let mut right_node_mut = self.read_leaf_node(parent.children[child_idx])?;
 						self.redistribute_leaf_from_left(
 							parent,
@@ -2224,7 +2224,7 @@ impl<F: VfsFile> BPlusTree<F> {
 					if !right_node.is_underflow() {
 						let mut left_node_mut =
 							self.read_internal_node(parent.children[child_idx])?;
-						let mut right_node_mut = self.extract_internal_mut(right_arc.clone());
+						let mut right_node_mut = self.extract_internal_mut(Arc::clone(right_arc));
 						self.redistribute_internal_from_right(
 							parent,
 							child_idx,
@@ -2240,7 +2240,7 @@ impl<F: VfsFile> BPlusTree<F> {
 					// Check if right sibling has enough to redistribute and is not in underflow
 					if !right_node.is_underflow() {
 						let mut left_node_mut = self.read_leaf_node(parent.children[child_idx])?;
-						let mut right_node_mut = self.extract_leaf_mut(right_arc.clone());
+						let mut right_node_mut = self.extract_leaf_mut(Arc::clone(right_arc));
 						self.redistribute_leaf_from_right(
 							parent,
 							child_idx,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -125,7 +125,7 @@ impl BlockCache {
 		}
 
 		match item.as_ref()? {
-			Item::Data(block) => Some(block.clone()),
+			Item::Data(block) => Some(Arc::clone(block)),
 			_ => None,
 		}
 	}
@@ -145,7 +145,7 @@ impl BlockCache {
 		}
 
 		match item.as_ref()? {
-			Item::Index(block) => Some(block.clone()),
+			Item::Index(block) => Some(Arc::clone(block)),
 			_ => None,
 		}
 	}

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -266,11 +266,11 @@ impl CommitPipeline {
 		let (commit_batch, complete_rx) = CommitBatch::new(batch.count());
 
 		// Phase 1: Assign sequence number and write to WAL (serialized)
-		let processed_batch = self.prepare(&mut batch, commit_batch.clone(), sync)?;
+		let processed_batch = self.prepare(&mut batch, Arc::clone(&commit_batch), sync)?;
 
 		// Phase 2: Apply to memtable (concurrent)
 		let apply_result = {
-			let env = self.env.clone();
+			let env = Arc::clone(&self.env);
 			env.apply(&processed_batch)
 		};
 

--- a/src/compaction/compactor.rs
+++ b/src/compaction/compactor.rs
@@ -29,9 +29,9 @@ pub(crate) struct CompactionOptions {
 impl CompactionOptions {
 	pub(crate) fn from(tree: &CoreInner) -> Self {
 		Self {
-			lopts: tree.opts.clone(),
-			level_manifest: tree.level_manifest.clone(),
-			immutable_memtables: tree.immutable_memtables.clone(),
+			lopts: Arc::clone(&tree.opts),
+			level_manifest: Arc::clone(&tree.level_manifest),
+			immutable_memtables: Arc::clone(&tree.immutable_memtables),
 			vlog: tree.vlog.clone(),
 		}
 	}
@@ -131,7 +131,7 @@ impl Compactor {
 	) -> Result<HashMap<u32, i64>> {
 		let file = SysFile::create(path)?;
 		let mut writer =
-			TableWriter::new(file, table_id, self.options.lopts.clone(), input.target_level);
+			TableWriter::new(file, table_id, Arc::clone(&self.options.lopts), input.target_level);
 
 		// Create a compaction iterator that filters tombstones
 		let max_level = self.options.lopts.level_count - 1;
@@ -143,7 +143,7 @@ impl Compactor {
 			self.options.vlog.clone(),
 			self.options.lopts.enable_versioning,
 			self.options.lopts.versioned_history_retention_ns,
-			self.options.lopts.clock.clone(),
+			Arc::clone(&self.options.lopts.clock),
 		);
 
 		for (key, value) in &mut comp_iter {
@@ -215,6 +215,6 @@ impl Compactor {
 		let file: Arc<dyn File> = Arc::new(file);
 		let file_size = file.size()?;
 
-		Ok(Arc::new(Table::new(table_id, self.options.lopts.clone(), file, file_size)?))
+		Ok(Arc::new(Table::new(table_id, Arc::clone(&self.options.lopts), file, file_size)?))
 	}
 }

--- a/src/levels/mod.rs
+++ b/src/levels/mod.rs
@@ -213,7 +213,7 @@ impl LevelManifest {
 
 			for &table_id in table_ids {
 				// Load the actual table from disk
-				match Self::load_table(table_id, opts.clone()) {
+				match Self::load_table(table_id, Arc::clone(&opts)) {
 					Ok(table) => tables.push(table),
 					Err(err) => {
 						log::error!("Error loading table {table_id}: {err:?}");
@@ -377,10 +377,10 @@ impl LevelManifest {
 				let level_mut = Arc::make_mut(level_ref);
 				if *level == 0 {
 					// Level 0: sorted by sequence number (tables can overlap)
-					level_mut.insert(table.clone());
+					level_mut.insert(Arc::clone(table));
 				} else {
 					// Level 1+: sorted by smallest key (tables cannot overlap)
-					level_mut.insert_sorted_by_key(table.clone());
+					level_mut.insert_sorted_by_key(Arc::clone(table));
 				}
 			}
 

--- a/src/memtable/mod.rs
+++ b/src/memtable/mod.rs
@@ -204,17 +204,17 @@ impl MemTable {
 
 		{
 			let file = SysFile::create(&table_file_path)?;
-			let mut table_writer = TableWriter::new(file, table_id, lsm_opts.clone(), 0); // Memtables always flush to L0
+			let mut table_writer = TableWriter::new(file, table_id, Arc::clone(&lsm_opts), 0); // Memtables always flush to L0
 
 			let iter = self.iter(false);
 			let iter = Box::new(iter);
 			let mut comp_iter = CompactionIterator::new(
 				vec![iter],
-				false,                  // not bottom level (L0 flush)
-				None,                   // no vlog access in flush context
-				false,                  // versioning disabled in flush context
-				0,                      // retention period is 0 in flush context
-				lsm_opts.clock.clone(), // clock is the system clock
+				false,                       // not bottom level (L0 flush)
+				None,                        // no vlog access in flush context
+				false,                       // versioning disabled in flush context
+				0,                           // retention period is 0 in flush context
+				Arc::clone(&lsm_opts.clock), // clock is the system clock
 			);
 			for (key, encoded_val) in comp_iter.by_ref() {
 				// The memtable already contains the correct ValueLocation encoding

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -114,7 +114,7 @@ impl Oracle {
 		});
 
 		// Insert into queue with version
-		let version = self.atomic_commit(commit_entry.clone())?;
+		let version = self.atomic_commit(Arc::clone(&commit_entry))?;
 
 		// Check for conflicts
 		let has_conflict = self.check_conflicts(version, txn.start_commit_id, &commit_entry)?;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -142,14 +142,15 @@ impl Snapshot {
 	/// Collects the iterator state from all LSM components
 	/// This is a helper method used by both iterators and optimized operations like count
 	pub(crate) fn collect_iter_state(&self) -> Result<IterState> {
-		let active = guardian::ArcRwLockReadGuardian::take(self.core.active_memtable.clone())?;
+		let active = guardian::ArcRwLockReadGuardian::take(Arc::clone(&self.core.active_memtable))?;
 		let immutable =
-			guardian::ArcRwLockReadGuardian::take(self.core.immutable_memtables.clone())?;
-		let manifest = guardian::ArcRwLockReadGuardian::take(self.core.level_manifest.clone())?;
+			guardian::ArcRwLockReadGuardian::take(Arc::clone(&self.core.immutable_memtables))?;
+		let manifest =
+			guardian::ArcRwLockReadGuardian::take(Arc::clone(&self.core.level_manifest))?;
 
 		Ok(IterState {
 			active: active.clone(),
-			immutable: immutable.iter().map(|entry| entry.memtable.clone()).collect(),
+			immutable: immutable.iter().map(|entry| Arc::clone(&entry.memtable)).collect(),
 			levels: manifest.levels.clone(),
 		})
 	}
@@ -275,7 +276,7 @@ impl Snapshot {
 	) -> Result<impl DoubleEndedIterator<Item = IterResult>> {
 		// Create a range from start (inclusive) to end (exclusive)
 		let range = start.as_ref().to_vec()..end.as_ref().to_vec();
-		SnapshotIterator::new_from(self.core.clone(), self.seq_num, range, keys_only)
+		SnapshotIterator::new_from(Arc::clone(&self.core), self.seq_num, range, keys_only)
 	}
 
 	/// Queries the versioned index for a specific key at a specific timestamp
@@ -349,7 +350,7 @@ impl Snapshot {
 
 		Ok(ScanAtTimestampIterator {
 			inner: versioned_iter,
-			core: self.core.clone(),
+			core: Arc::clone(&self.core),
 		})
 	}
 
@@ -882,7 +883,7 @@ impl SnapshotIterator<'_> {
 	{
 		// Create a temporary snapshot to use the helper method
 		let snapshot = Snapshot {
-			core: core.clone(),
+			core: Arc::clone(&core),
 			seq_num,
 		};
 		let iter_state = snapshot.collect_iter_state()?;

--- a/src/sstable/block.rs
+++ b/src/sstable/block.rs
@@ -93,7 +93,7 @@ pub(crate) struct Block {
 
 impl Block {
 	pub(crate) fn iter(&self, keys_only: bool) -> BlockIterator {
-		BlockIterator::new(self.opts.clone(), self.block.clone(), keys_only)
+		BlockIterator::new(Arc::clone(&self.opts), self.block.clone(), keys_only)
 	}
 
 	pub(crate) fn new(data: BlockData, opts: Arc<Options>) -> Block {
@@ -176,7 +176,7 @@ impl BlockWriter {
 	// Constructor for BlockWriter
 	pub(crate) fn new(opt: Arc<Options>) -> Self {
 		BlockWriter {
-			internal_cmp: Arc::new(InternalKeyComparator::new(opt.comparator.clone())),
+			internal_cmp: Arc::new(InternalKeyComparator::new(Arc::clone(&opt.comparator))),
 			buffer: Vec::with_capacity(opt.block_size),
 			restart_interval: opt.block_restart_interval,
 			restart_points: vec![0],
@@ -344,7 +344,8 @@ impl BlockIterator {
 			*restart_point = u32::decode_fixed(&block[start_point..end_point]).unwrap();
 		}
 
-		let internal_comparator = Arc::new(InternalKeyComparator::new(options.comparator.clone()));
+		let internal_comparator =
+			Arc::new(InternalKeyComparator::new(Arc::clone(&options.comparator)));
 
 		BlockIterator {
 			block,

--- a/src/sstable/index_block.rs
+++ b/src/sstable/index_block.rs
@@ -57,7 +57,7 @@ pub(crate) struct TopLevelIndexWriter {
 impl TopLevelIndexWriter {
 	pub(crate) fn new(opts: Arc<Options>, max_block_size: usize) -> TopLevelIndexWriter {
 		TopLevelIndexWriter {
-			opts: opts.clone(),
+			opts: Arc::clone(&opts),
 			index_blocks: Vec::new(),
 			current_block: BlockWriter::new(opts),
 			max_block_size,
@@ -87,7 +87,7 @@ impl TopLevelIndexWriter {
 	}
 
 	fn finish_current_block(&mut self) {
-		let new_block = BlockWriter::new(self.opts.clone());
+		let new_block = BlockWriter::new(Arc::clone(&self.opts));
 		let finished_block = std::mem::replace(&mut self.current_block, new_block);
 		self.index_blocks.push(finished_block);
 	}
@@ -159,7 +159,7 @@ impl TopLevelIndex {
 		f: Arc<dyn File>,
 		location: &BlockHandle,
 	) -> Result<Self> {
-		let block = read_table_block(opt.clone(), f.clone(), location)?;
+		let block = read_table_block(Arc::clone(&opt), Arc::clone(&f), location)?;
 		let iter = block.iter(false);
 		let mut blocks = Vec::new();
 		for (key, handle) in iter {
@@ -175,7 +175,7 @@ impl TopLevelIndex {
 			id,
 			opts: opt,
 			blocks,
-			file: f.clone(),
+			file: Arc::clone(&f),
 		})
 	}
 
@@ -202,9 +202,13 @@ impl TopLevelIndex {
 		}
 
 		let block_data =
-			read_table_block(self.opts.clone(), self.file.clone(), &block_handle.handle)?;
+			read_table_block(Arc::clone(&self.opts), Arc::clone(&self.file), &block_handle.handle)?;
 		let block = Arc::new(block_data);
-		self.opts.block_cache.insert_index_block(self.id, block_handle.offset(), block.clone());
+		self.opts.block_cache.insert_index_block(
+			self.id,
+			block_handle.offset(),
+			Arc::clone(&block),
+		);
 
 		Ok(block)
 	}

--- a/src/sstable/table.rs
+++ b/src/sstable/table.rs
@@ -187,7 +187,7 @@ impl<W: Write> TableWriter<W> {
 	pub(crate) fn new(writer: W, id: u64, opts: Arc<Options>, target_level: u8) -> Self {
 		let fb = {
 			if let Some(policy) = opts.filter_policy.clone() {
-				let mut f = FilterBlockWriter::new(policy.clone());
+				let mut f = FilterBlockWriter::new(Arc::clone(&policy));
 				f.start_block(0);
 				Some(f)
 			} else {
@@ -202,17 +202,20 @@ impl<W: Write> TableWriter<W> {
 
 		TableWriter {
 			writer,
-			opts: opts.clone(),
+			opts: Arc::clone(&opts),
 			compression_selector,
 			target_level,
 			offset: 0,
 			meta,
 			prev_block_last_key: Vec::new(),
 
-			data_block: Some(BlockWriter::new(opts.clone())),
-			partitioned_index: TopLevelIndexWriter::new(opts.clone(), opts.index_partition_size),
+			data_block: Some(BlockWriter::new(Arc::clone(&opts))),
+			partitioned_index: TopLevelIndexWriter::new(
+				Arc::clone(&opts),
+				opts.index_partition_size,
+			),
 			filter_block: fb,
-			internal_cmp: Arc::new(InternalKeyComparator::new(opts.comparator.clone())),
+			internal_cmp: Arc::new(InternalKeyComparator::new(Arc::clone(&opts.comparator))),
 		}
 	}
 
@@ -246,7 +249,7 @@ impl<W: Write> TableWriter<W> {
 		// Initialize filter block on first key
 		if self.filter_block.is_none() && self.opts.filter_policy.is_some() {
 			self.filter_block =
-				Some(FilterBlockWriter::new(self.opts.filter_policy.as_ref().unwrap().clone()));
+				Some(FilterBlockWriter::new(Arc::clone(self.opts.filter_policy.as_ref().unwrap())));
 			// The offset is 0 for the entire SST
 			self.filter_block.as_mut().unwrap().start_block(0);
 		}
@@ -305,7 +308,7 @@ impl<W: Write> TableWriter<W> {
 		self.partitioned_index.add(&separator_key, &handle_encoded)?;
 
 		// Prepare for the next data block.
-		self.data_block = Some(BlockWriter::new(self.opts.clone()));
+		self.data_block = Some(BlockWriter::new(Arc::clone(&self.opts)));
 
 		Ok(())
 	}
@@ -331,7 +334,7 @@ impl<W: Write> TableWriter<W> {
 		}
 
 		// Initialize meta_index block
-		let mut meta_ix_block = BlockWriter::new(self.opts.clone());
+		let mut meta_ix_block = BlockWriter::new(Arc::clone(&self.opts));
 
 		// Write the filter block to the meta index block if present.
 		if let Some(fblock) = self.filter_block.take() {
@@ -567,13 +570,13 @@ pub(crate) fn read_table_block(
 	f: Arc<dyn File>,
 	location: &BlockHandle,
 ) -> Result<Block> {
-	let buf = read_bytes(f.clone(), location)?;
+	let buf = read_bytes(Arc::clone(&f), location)?;
 	let compress = read_bytes(
-		f.clone(),
+		Arc::clone(&f),
 		&BlockHandle::new(location.offset() + location.size(), BLOCK_COMPRESS_LEN),
 	)?;
 	let cksum = read_bytes(
-		f.clone(),
+		Arc::clone(&f),
 		&BlockHandle::new(
 			location.offset() + location.size() + BLOCK_COMPRESS_LEN,
 			BLOCK_CKSUM_LEN,
@@ -634,17 +637,18 @@ impl Table {
 		//    3. [meta block: properties]
 		//    4. [meta block: filter]
 
-		let footer = read_footer(file.clone(), file_size as usize)?;
+		let footer = read_footer(Arc::clone(&file), file_size as usize)?;
 		// println!("meta ix handle: {:?}", footer.meta_index);
 
 		// Using partitioned index
 		let index_block = {
 			let partitioned_index =
-				TopLevelIndex::new(id, opts.clone(), file.clone(), &footer.index)?;
+				TopLevelIndex::new(id, Arc::clone(&opts), Arc::clone(&file), &footer.index)?;
 			IndexType::Partitioned(partitioned_index)
 		};
 
-		let metaindexblock = read_table_block(opts.clone(), file.clone(), &footer.meta_index)?;
+		let metaindexblock =
+			read_table_block(Arc::clone(&opts), Arc::clone(&file), &footer.meta_index)?;
 		// println!("meta block: {:?}", metaindexblock.block);
 
 		let writer_metadata =
@@ -653,7 +657,7 @@ impl Table {
 
 		let filter_reader = if opts.filter_policy.is_some() {
 			// Read the filter block if filter policy is present
-			Self::read_filter_block(&metaindexblock, file.clone(), &opts)?
+			Self::read_filter_block(&metaindexblock, Arc::clone(&file), &opts)?
 		} else {
 			None
 		};
@@ -662,7 +666,7 @@ impl Table {
 			id,
 			file,
 			file_size,
-			internal_cmp: Arc::new(InternalKeyComparator::new(opts.comparator.clone())),
+			internal_cmp: Arc::new(InternalKeyComparator::new(Arc::clone(&opts.comparator))),
 			opts,
 			filter_reader,
 			index_block,
@@ -709,7 +713,7 @@ impl Table {
 				return Ok(Some(read_filter_block(
 					file,
 					&filter_block_location,
-					options.filter_policy.as_ref().unwrap().clone(),
+					Arc::clone(options.filter_policy.as_ref().unwrap()),
 				)?));
 			}
 		}
@@ -722,10 +726,10 @@ impl Table {
 			return Ok(block);
 		}
 
-		let b = read_table_block(self.opts.clone(), self.file.clone(), location)?;
+		let b = read_table_block(Arc::clone(&self.opts), Arc::clone(&self.file), location)?;
 		let b = Arc::new(b);
 
-		self.opts.block_cache.insert_data_block(self.id, location.offset() as u64, b.clone());
+		self.opts.block_cache.insert_data_block(self.id, location.offset() as u64, Arc::clone(&b));
 
 		Ok(b)
 	}
@@ -810,9 +814,9 @@ impl Table {
 					first_block.iter(false)
 				} else {
 					// If there are no partitions, create a proper empty block
-					let empty_writer = BlockWriter::new(self.opts.clone());
+					let empty_writer = BlockWriter::new(Arc::clone(&self.opts));
 					let empty_block_data = empty_writer.finish();
-					let empty_block = Block::new(empty_block_data, self.opts.clone());
+					let empty_block = Block::new(empty_block_data, Arc::clone(&self.opts));
 					empty_block.iter(false)
 				}
 			}

--- a/src/task.rs
+++ b/src/task.rs
@@ -54,11 +54,11 @@ impl TaskManager {
 
 		// Spawn memtable compaction task
 		{
-			let core = core.clone();
-			let stop_flag = stop_flag.clone();
-			let notify = memtable_notify.clone();
-			let running = memtable_running.clone();
-			let level_notify = level_notify.clone();
+			let core = Arc::clone(&core);
+			let stop_flag = Arc::clone(&stop_flag);
+			let notify = Arc::clone(&memtable_notify);
+			let running = Arc::clone(&memtable_running);
+			let level_notify = Arc::clone(&level_notify);
 
 			let handle = tokio::spawn(async move {
 				loop {
@@ -88,10 +88,10 @@ impl TaskManager {
 
 		// Spawn level compaction task
 		{
-			let core = core.clone();
-			let stop_flag = stop_flag.clone();
-			let notify = level_notify.clone();
-			let running = level_running.clone();
+			let core = Arc::clone(&core);
+			let stop_flag = Arc::clone(&stop_flag);
+			let notify = Arc::clone(&level_notify);
+			let running = Arc::clone(&level_running);
 
 			let handle = tokio::spawn(async move {
 				loop {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -219,7 +219,7 @@ impl Transaction {
 
 		let mut snapshot = None;
 		if !mode.is_write_only() {
-			snapshot = Some(Snapshot::new(core.clone(), read_ts));
+			snapshot = Some(Snapshot::new(Arc::clone(&core), read_ts));
 		}
 
 		Ok(Self {


### PR DESCRIPTION
The point of this lint is to make it very clear where we're cheaply cloning a reference counted pointer vs where we're making a potentially expensive clone. All `.clone()` statements should be treated as potential issues after this change (with the exception of clones on `Bytes`).