### PR TITLE
Use Bytes internally in Bplustree

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -500,7 +500,10 @@ impl Snapshot {
 
 				let current_key = internal_key.user_key.clone();
 
-				key_versions.entry(current_key).or_default().push((internal_key, encoded_value));
+				key_versions
+					.entry(current_key)
+					.or_default()
+					.push((internal_key, encoded_value.to_vec()));
 			}
 
 			// Filter out keys where the latest version is a hard delete


### PR DESCRIPTION
Currently Bplustree is tired to the Key and Value types. If the types change, it affects the performance of the tree. This PR makes the internals of B+ Tree independent from the lsm types