### PR TITLE
Fix unhide bug on manifest

### DIFF
--- a/src/compaction/compactor.rs
+++ b/src/compaction/compactor.rs
@@ -14,6 +14,37 @@ use crate::vfs::File;
 use crate::vlog::VLog;
 use crate::Options as LSMOptions;
 
+/// RAII guard to ensure tables are unhidden if compaction fails
+struct HiddenTablesGuard {
+	level_manifest: Arc<RwLock<LevelManifest>>,
+	table_ids: Vec<u64>,
+	committed: bool,
+}
+
+impl HiddenTablesGuard {
+	fn new(level_manifest: Arc<RwLock<LevelManifest>>, table_ids: &[u64]) -> Self {
+		Self {
+			level_manifest,
+			table_ids: table_ids.to_vec(),
+			committed: false,
+		}
+	}
+
+	fn commit(&mut self) {
+		self.committed = true;
+	}
+}
+
+impl Drop for HiddenTablesGuard {
+	fn drop(&mut self) {
+		if !self.committed {
+			if let Ok(mut levels) = self.level_manifest.write() {
+				levels.unhide_tables(&self.table_ids);
+			}
+		}
+	}
+}
+
 /// Compaction options
 pub(crate) struct CompactionOptions {
 	pub(crate) lopts: Arc<LSMOptions>,
@@ -64,57 +95,64 @@ impl Compactor {
 		mut levels: RwLockWriteGuard<'_, LevelManifest>,
 		input: &CompactionInput,
 	) -> Result<()> {
-		let merge_result = {
-			let tables = levels.get_all_tables();
+		// Hide tables that are being merged
+		levels.hide_tables(&input.tables_to_merge);
 
-			let to_merge: Vec<_> =
-				input.tables_to_merge.iter().filter_map(|&id| tables.get(&id).cloned()).collect();
+		// Create guard to ensure tables are unhidden on error
+		let mut guard = HiddenTablesGuard::new(
+			Arc::clone(&self.options.level_manifest),
+			&input.tables_to_merge,
+		);
 
-			let iterators: Vec<BoxedIterator<'_>> = to_merge
-				.into_iter()
-				.map(|table| Box::new(table.iter(false, None)) as BoxedIterator<'_>)
-				.collect();
+		let tables = levels.get_all_tables();
+		let to_merge: Vec<_> =
+			input.tables_to_merge.iter().filter_map(|&id| tables.get(&id).cloned()).collect();
 
-			// Hide tables that are being merged
-			levels.hide_tables(&input.tables_to_merge);
-			drop(levels);
+		let iterators: Vec<BoxedIterator<'_>> = to_merge
+			.into_iter()
+			.map(|table| Box::new(table.iter(false, None)) as BoxedIterator<'_>)
+			.collect();
 
-			// Create new table
-			let new_table_id = self.options.level_manifest.read().unwrap().next_table_id();
-			let new_table_path = self.get_table_path(new_table_id);
+		drop(levels);
 
-			// Write merged data - returns (table_created, discard_stats)
-			let (table_created, discard_stats) =
-				self.write_merged_table(&new_table_path, new_table_id, iterators, input)?;
+		// Create new table
+		let new_table_id = self.options.level_manifest.read().unwrap().next_table_id();
+		let new_table_path = self.get_table_path(new_table_id);
 
-			// Open table only if one was created
-			let new_table = if table_created {
-				Some(self.open_table(new_table_id, &new_table_path)?)
-			} else {
-				None
+		// Write merged data - returns (table_created, discard_stats)
+		let (table_created, discard_stats) =
+			match self.write_merged_table(&new_table_path, new_table_id, iterators, input) {
+				Ok(result) => result,
+				Err(e) => {
+					// Guard will unhide tables on drop
+					return Err(e);
+				}
 			};
 
-			Ok((new_table, discard_stats))
+		// Open table only if one was created
+		let new_table = if table_created {
+			match self.open_table(new_table_id, &new_table_path) {
+				Ok(table) => Some(table),
+				Err(e) => {
+					// Guard will unhide tables on drop
+					return Err(e);
+				}
+			}
+		} else {
+			None
 		};
 
-		match merge_result {
-			Ok((new_table, discard_stats)) => {
-				self.update_manifest(input, new_table)?;
-				self.cleanup_old_tables(input);
+		// Update manifest - this will commit the guard on success
+		self.update_manifest(input, new_table, &mut guard)?;
 
-				if !discard_stats.is_empty() {
-					if let Some(ref vlog) = self.options.vlog {
-						vlog.update_discard_stats(&discard_stats);
-					}
-				}
-				Ok(())
-			}
-			Err(e) => {
-				let mut levels = self.options.level_manifest.write()?;
-				levels.unhide_tables(&input.tables_to_merge);
-				Err(e)
+		self.cleanup_old_tables(input);
+
+		if !discard_stats.is_empty() {
+			if let Some(ref vlog) = self.options.vlog {
+				vlog.update_discard_stats(&discard_stats);
 			}
 		}
+		Ok(())
 	}
 
 	/// Returns (table_created, discard_stats)
@@ -171,6 +209,7 @@ impl Compactor {
 		&self,
 		input: &CompactionInput,
 		new_table: Option<Arc<Table>>,
+		guard: &mut HiddenTablesGuard,
 	) -> Result<()> {
 		let mut manifest = self.options.level_manifest.write()?;
 		let _imm_guard = self.options.immutable_memtables.write();
@@ -198,16 +237,23 @@ impl Compactor {
 			changeset.new_tables.push((input.target_level, table));
 		}
 
-		manifest.apply_changeset(&changeset)?;
+		let rollback = manifest.apply_changeset(&changeset)?;
 
+		// Write manifest to disk - if this fails, revert in-memory state
 		if let Err(e) = write_manifest_to_disk(&manifest) {
+			manifest.revert_changeset(rollback);
 			self.options
 				.error_handler
 				.set_error(e.clone(), crate::error::BackgroundErrorReason::ManifestWrite);
 			return Err(e);
 		}
 
+		// Unhide tables before committing guard (they'll be removed from manifest anyway)
 		manifest.unhide_tables(&input.tables_to_merge);
+
+		// Commit guard - tables are now properly handled in manifest
+		guard.commit();
+
 		Ok(())
 	}
 

--- a/src/test/index_block_tests.rs
+++ b/src/test/index_block_tests.rs
@@ -534,3 +534,363 @@ fn test_partition_lookup_exact_separator_match() {
 	let (idx, _) = result.unwrap();
 	assert_eq!(idx, 1, "Exact match should return that partition");
 }
+
+#[test]
+fn test_partitioned_index_seek_correctness() {
+	// Test Seek correctness with multiple partitions
+	let opts = Options {
+		index_partition_size: 100, // Small partition size to force multiple partitions
+		block_size: 1700,          // Larger block size to create multiple data blocks
+		..Default::default()
+	};
+	let opts = Arc::new(opts);
+
+	let mut buffer = Vec::new();
+	let mut writer = crate::sstable::table::TableWriter::new(&mut buffer, 0, Arc::clone(&opts), 0);
+
+	// Create keys with prefix length 3, make sure the key/value is big enough to fill one block
+	// Pattern: "0015", "0035", "0054", "0055", "0056", "0057", "0058", "0075", "0076", "0095"
+	let test_keys =
+		vec!["0015", "0035", "0054", "0055", "0056", "0057", "0058", "0075", "0076", "0095"];
+
+	for (seq, key) in test_keys.iter().enumerate() {
+		let internal_key =
+			InternalKey::new(key.as_bytes().to_vec(), (seq + 1) as u64, InternalKeyKind::Set, 0);
+		let value = format!("v-{key}").into_bytes();
+		writer.add(internal_key, &value).unwrap();
+	}
+
+	let size = writer.finish().unwrap();
+	let table = Arc::new(
+		crate::sstable::table::Table::new(0, opts, wrap_buffer(buffer), size as u64).unwrap(),
+	);
+
+	// Verify we have partitioned index
+	let crate::sstable::table::IndexType::Partitioned(_) = &table.index_block;
+
+	// Test Seek to existing keys
+	for (seq, key) in test_keys.iter().enumerate() {
+		let seek_key =
+			InternalKey::new(key.as_bytes().to_vec(), (seq + 1) as u64, InternalKeyKind::Set, 0);
+		let result = table.get(&seek_key).unwrap();
+		assert!(result.is_some(), "Should find key {key}");
+		if let Some((found_key, found_value)) = result {
+			assert_eq!(
+				std::str::from_utf8(&found_key.user_key).unwrap(),
+				*key,
+				"Key mismatch for {key}"
+			);
+			assert_eq!(
+				std::str::from_utf8(found_value.as_ref()).unwrap(),
+				format!("v-{key}"),
+				"Value mismatch for {key}"
+			);
+		}
+	}
+
+	// Test Seek to non-existing keys (between blocks)
+	let non_existing_keys = vec!["0016", "0036", "0053", "0059", "0074", "0077", "0094"];
+	for key in &non_existing_keys {
+		let seek_key = InternalKey::new(key.as_bytes().to_vec(), 100, InternalKeyKind::Set, 0);
+		let result = table.get(&seek_key).unwrap();
+		// Should either find the next key or return None
+		if let Some((found_key, _)) = result {
+			// If found, verify it's a valid key
+			let found_str = std::str::from_utf8(&found_key.user_key).unwrap();
+			assert!(test_keys.contains(&found_str), "Found key {found_str} should be in test_keys");
+		}
+	}
+
+	// Test SeekForPrev - iterate backwards
+	let mut iter = table.iter(false, None);
+	iter.seek_to_last().unwrap();
+	assert!(iter.valid(), "Iterator should be valid after seek_to_last");
+
+	let mut backward_keys = Vec::new();
+	backward_keys.push(std::str::from_utf8(&iter.key().user_key).unwrap().to_string());
+	while iter.prev().unwrap() {
+		backward_keys.push(std::str::from_utf8(&iter.key().user_key).unwrap().to_string());
+	}
+
+	// Verify backward iteration matches reverse of forward iteration
+	let mut forward_keys: Vec<String> = test_keys.iter().map(|s| (*s).to_string()).collect();
+	forward_keys.reverse();
+	assert_eq!(
+		backward_keys, forward_keys,
+		"Backward iteration should match reverse forward iteration"
+	);
+}
+
+#[test]
+fn test_partitioned_index_boundary_keys() {
+	// Test keys at exact partition boundaries
+	let opts = Options {
+		index_partition_size: 50, // Small partition size to force multiple partitions
+		block_size: 500,
+		..Default::default()
+	};
+
+	let opts = Arc::new(opts);
+
+	let mut buffer = Vec::new();
+	let mut writer = crate::sstable::table::TableWriter::new(&mut buffer, 0, Arc::clone(&opts), 0);
+
+	// Create keys that will span multiple partitions
+	// Add enough keys to create at least 3 partitions
+	for i in 0..50 {
+		let key = format!("key_{i:03}");
+		let internal_key =
+			InternalKey::new(key.as_bytes().to_vec(), (i + 1) as u64, InternalKeyKind::Set, 0);
+		let value = format!("value_{i:03}").into_bytes();
+		writer.add(internal_key, &value).unwrap();
+	}
+
+	let size = writer.finish().unwrap();
+	let table = Arc::new(
+		crate::sstable::table::Table::new(0, opts, wrap_buffer(buffer), size as u64).unwrap(),
+	);
+
+	let crate::sstable::table::IndexType::Partitioned(ref partitioned_index) = table.index_block;
+
+	assert!(partitioned_index.blocks.len() >= 2, "Should have at least 2 partitions");
+
+	// Test first key in first partition
+	let first_key = InternalKey::new(b"key_000".to_vec(), 1, InternalKeyKind::Set, 0);
+	let result = table.get(&first_key).unwrap();
+	assert!(result.is_some(), "Should find first key");
+
+	// Test last key in last partition
+	let last_key = InternalKey::new(b"key_049".to_vec(), 50, InternalKeyKind::Set, 0);
+	let result = table.get(&last_key).unwrap();
+	assert!(result.is_some(), "Should find last key");
+
+	// Test keys just before/after partition boundaries
+	// Get separator keys to understand boundaries
+	for (idx, block) in partitioned_index.blocks.iter().enumerate() {
+		let sep_key = InternalKey::decode(&block.separator_key);
+		let sep_user_key = std::str::from_utf8(&sep_key.user_key).unwrap();
+
+		// Test key just before separator
+		if idx > 0 {
+			// Try to find a key that should be in previous partition
+			let test_key = InternalKey::new(
+				sep_user_key.as_bytes().to_vec(),
+				sep_key.seq_num() + 1, // Higher seq = earlier in ordering
+				InternalKeyKind::Set,
+				0,
+			);
+			let result = table.get(&test_key).unwrap();
+			// Should find something (might be in previous partition)
+			if result.is_some() {
+				let (found_key, _) = result.unwrap();
+				assert!(found_key.user_key <= sep_key.user_key, "Found key should be <= separator");
+			}
+		}
+	}
+}
+
+#[test]
+fn test_partitioned_index_reseek() {
+	let opts = Options {
+		index_partition_size: 100,
+		block_size: 1700,
+		..Default::default()
+	};
+
+	let opts = Arc::new(opts);
+
+	let mut buffer = Vec::new();
+	let mut writer = crate::sstable::table::TableWriter::new(&mut buffer, 0, Arc::clone(&opts), 0);
+
+	let test_keys =
+		vec!["0015", "0035", "0054", "0055", "0056", "0057", "0058", "0075", "0076", "0095"];
+
+	for (seq, key) in test_keys.iter().enumerate() {
+		let internal_key =
+			InternalKey::new(key.as_bytes().to_vec(), (seq + 1) as u64, InternalKeyKind::Set, 0);
+		let value = format!("v-{key}").into_bytes();
+		writer.add(internal_key, &value).unwrap();
+	}
+
+	let size = writer.finish().unwrap();
+	let table = Arc::new(
+		crate::sstable::table::Table::new(0, opts, wrap_buffer(buffer), size as u64).unwrap(),
+	);
+
+	let mut iter = table.iter(false, None);
+
+	// Seek to middle key
+	let seek_key = InternalKey::new(b"0055".to_vec(), 4, InternalKeyKind::Set, 0);
+	iter.seek(&seek_key.encode()).unwrap();
+	assert!(iter.valid(), "Iterator should be valid after seek");
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0055", "Should find key 0055");
+
+	// SeekToLast
+	iter.seek_to_last().unwrap();
+	assert!(iter.valid(), "Iterator should be valid after seek_to_last");
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0095", "Should find last key");
+
+	// Reseek to same key - should work correctly
+	iter.seek(&seek_key.encode()).unwrap();
+	assert!(iter.valid(), "Iterator should be valid after reseek");
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0055",
+		"Should find key 0055 after reseek"
+	);
+
+	// SeekToLast again
+	iter.seek_to_last().unwrap();
+	assert!(iter.valid(), "Iterator should be valid after second seek_to_last");
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0095",
+		"Should find last key again"
+	);
+
+	// Prev twice
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0075",
+		"Should find key 0075 after two prev()"
+	);
+
+	// Seek to 0095
+	let seek_key_0095 = InternalKey::new(b"0095".to_vec(), 10, InternalKeyKind::Set, 0);
+	iter.seek(&seek_key_0095.encode()).unwrap();
+	assert!(iter.valid());
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0095", "Should find key 0095");
+
+	// Prev twice
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0075",
+		"Should find key 0075 after prev from 0095"
+	);
+
+	// SeekToLast
+	iter.seek_to_last().unwrap();
+	assert!(iter.valid());
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0095", "Should find last key");
+
+	// Seek to 0095 again
+	iter.seek(&seek_key_0095.encode()).unwrap();
+	assert!(iter.valid());
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0095",
+		"Should find key 0095 after reseek"
+	);
+
+	// Prev twice
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	iter.prev().unwrap();
+	assert!(iter.valid());
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0075", "Should find key 0075");
+
+	// Seek to 0075
+	let seek_key_0075 = InternalKey::new(b"0075".to_vec(), 8, InternalKeyKind::Set, 0);
+	iter.seek(&seek_key_0075.encode()).unwrap();
+	assert!(iter.valid());
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0075", "Should find key 0075");
+
+	// Next twice
+	if let Some(result) = iter.next() {
+		result.unwrap();
+	}
+	assert!(iter.valid());
+	if let Some(result) = iter.next() {
+		result.unwrap();
+	}
+	assert!(iter.valid());
+	assert_eq!(
+		std::str::from_utf8(&iter.key().user_key).unwrap(),
+		"0095",
+		"Should find key 0095 after two next()"
+	);
+
+	// SeekToLast
+	iter.seek_to_last().unwrap();
+	assert!(iter.valid());
+	assert_eq!(std::str::from_utf8(&iter.key().user_key).unwrap(), "0095", "Should find last key");
+}
+
+#[test]
+fn test_partitioned_index_varying_partition_sizes() {
+	// Test with varying partition sizes to ensure all operations work
+	let max_index_keys = 5;
+	let est_max_index_key_value_size = 32;
+	let est_max_index_size = max_index_keys * est_max_index_key_value_size;
+
+	for partition_size in 1..=est_max_index_size + 1 {
+		let opts = Options {
+			index_partition_size: partition_size,
+			block_size: 500,
+			..Default::default()
+		};
+
+		let opts = Arc::new(opts);
+
+		let mut buffer = Vec::new();
+		let mut writer =
+			crate::sstable::table::TableWriter::new(&mut buffer, 0, Arc::clone(&opts), 0);
+
+		// Add enough entries to create multiple partitions
+		for i in 0..20 {
+			let key = format!("key_{i:03}");
+			let internal_key =
+				InternalKey::new(key.as_bytes().to_vec(), (i + 1) as u64, InternalKeyKind::Set, 0);
+			let value = format!("value_{i:03}").into_bytes();
+			writer.add(internal_key, &value).unwrap();
+		}
+
+		let size = writer.finish().unwrap();
+		let table = Arc::new(
+			crate::sstable::table::Table::new(0, opts, wrap_buffer(buffer), size as u64).unwrap(),
+		);
+
+		// Test Get operations work at this partition size
+		for i in 0..20 {
+			let key = format!("key_{i:03}");
+			let seek_key =
+				InternalKey::new(key.as_bytes().to_vec(), (i + 1) as u64, InternalKeyKind::Set, 0);
+			let result = table.get(&seek_key).unwrap();
+			assert!(result.is_some(), "Should find key {key} at partition_size {partition_size}");
+			if let Some((found_key, found_value)) = result {
+				assert_eq!(
+					std::str::from_utf8(&found_key.user_key).unwrap(),
+					key,
+					"Key mismatch at partition_size {partition_size}"
+				);
+				assert_eq!(
+					std::str::from_utf8(found_value.as_ref()).unwrap(),
+					format!("value_{i:03}"),
+					"Value mismatch at partition_size {partition_size}"
+				);
+			}
+		}
+
+		// Test iterator works at this partition size
+		let mut iter = table.iter(false, None);
+		iter.seek_to_first().unwrap();
+		let mut count = 0;
+		while iter.valid() {
+			count += 1;
+			match iter.next() {
+				Some(Ok(_)) => {}
+				Some(Err(e)) => panic!("Iterator error: {e}"),
+				None => break,
+			}
+		}
+		assert_eq!(count, 20, "Should iterate all 20 keys at partition_size {partition_size}");
+	}
+}

--- a/src/test/manifest_tests.rs
+++ b/src/test/manifest_tests.rs
@@ -663,3 +663,795 @@ fn test_manifest_v1_with_log_number_and_last_sequence() {
 	// Verify table loaded correctly
 	assert_eq!(loaded_manifest.levels.get_levels()[0].tables.len(), 1);
 }
+
+#[test]
+fn test_revert_empty_changeset() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let initial_last_sequence = manifest.get_last_sequence();
+	let initial_log_number = manifest.get_log_number();
+	let initial_version = manifest.manifest_format_version;
+
+	let changeset = ManifestChangeSet::default();
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.get_last_sequence(),
+		initial_last_sequence,
+		"last_sequence should be unchanged"
+	);
+	assert_eq!(manifest.get_log_number(), initial_log_number, "log_number should be unchanged");
+	assert_eq!(
+		manifest.manifest_format_version, initial_version,
+		"manifest_format_version should be unchanged"
+	);
+}
+
+#[test]
+fn test_revert_added_tables_only() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let initial_table_count_l0 = manifest.levels.get_levels()[0].tables.len();
+	let initial_table_count_l1 = manifest.levels.get_levels()[1].tables.len();
+
+	let changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (1, table2), (1, table3)],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), initial_table_count_l0 + 1);
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), initial_table_count_l1 + 2);
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.levels.get_levels()[0].tables.len(),
+		initial_table_count_l0,
+		"L0 table count should be restored"
+	);
+	assert_eq!(
+		manifest.levels.get_levels()[1].tables.len(),
+		initial_table_count_l1,
+		"L1 table count should be restored"
+	);
+}
+
+#[test]
+fn test_revert_deleted_tables_only() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add some tables first
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let add_changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (0, table2), (1, table3)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	let initial_table_count_l0 = manifest.levels.get_levels()[0].tables.len();
+	let initial_table_count_l1 = manifest.levels.get_levels()[1].tables.len();
+
+	// Now delete them
+	let delete_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(0, 1), (0, 2), (1, 3)]),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&delete_changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), initial_table_count_l0 - 2);
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), initial_table_count_l1 - 1);
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.levels.get_levels()[0].tables.len(),
+		initial_table_count_l0,
+		"L0 table count should be restored"
+	);
+	assert_eq!(
+		manifest.levels.get_levels()[1].tables.len(),
+		initial_table_count_l1,
+		"L1 table count should be restored"
+	);
+
+	// Verify table IDs are present
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 1));
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 2));
+	assert!(manifest.levels.get_levels()[1].tables.iter().any(|t| t.id == 3));
+}
+
+#[test]
+fn test_revert_mixed_add_delete() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add initial tables
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+
+	let add_changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (0, table2)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	let initial_table_count_l0 = manifest.levels.get_levels()[0].tables.len();
+
+	// Mixed: delete table1, add table3
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let mixed_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(0, 1)]),
+		new_tables: vec![(0, table3)],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&mixed_changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), initial_table_count_l0);
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 3));
+	assert!(!manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 1));
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.levels.get_levels()[0].tables.len(),
+		initial_table_count_l0,
+		"L0 table count should be restored"
+	);
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 1));
+	assert!(!manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 3));
+}
+
+#[test]
+fn test_revert_preserves_table_ordering_l0() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add tables with different sequence numbers
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let add_changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (0, table2), (0, table3)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	// Capture initial ordering
+	let initial_order: Vec<u64> =
+		manifest.levels.get_levels()[0].tables.iter().map(|t| t.id).collect();
+
+	// Delete and re-add to test ordering preservation
+	let delete_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(0, 2)]),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&delete_changeset).expect("Failed to apply changeset");
+
+	manifest.revert_changeset(rollback);
+
+	// Verify ordering is preserved
+	let restored_order: Vec<u64> =
+		manifest.levels.get_levels()[0].tables.iter().map(|t| t.id).collect();
+
+	assert_eq!(initial_order, restored_order, "L0 table ordering should be preserved");
+}
+
+#[test]
+fn test_revert_preserves_table_ordering_l1() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add tables to L1 (sorted by key)
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let add_changeset = ManifestChangeSet {
+		new_tables: vec![(1, table1), (1, table2), (1, table3)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	// Capture initial ordering
+	let initial_order: Vec<u64> =
+		manifest.levels.get_levels()[1].tables.iter().map(|t| t.id).collect();
+
+	// Delete and re-add to test ordering preservation
+	let delete_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(1, 2)]),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&delete_changeset).expect("Failed to apply changeset");
+
+	manifest.revert_changeset(rollback);
+
+	// Verify ordering is preserved
+	let restored_order: Vec<u64> =
+		manifest.levels.get_levels()[1].tables.iter().map(|t| t.id).collect();
+
+	assert_eq!(initial_order, restored_order, "L1+ table ordering should be preserved");
+}
+
+#[test]
+fn test_revert_log_number_change() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let initial_log_number = manifest.get_log_number();
+	let new_log_number = 42;
+
+	let changeset = ManifestChangeSet {
+		log_number: Some(new_log_number),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.get_log_number(), new_log_number, "log_number should be updated");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(manifest.get_log_number(), initial_log_number, "log_number should be reverted");
+}
+
+#[test]
+fn test_revert_log_number_not_changed() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Set log_number to a higher value first
+	let higher_log_number = 50;
+	let changeset1 = ManifestChangeSet {
+		log_number: Some(higher_log_number),
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&changeset1).expect("Failed to apply changeset");
+
+	let current_log_number = manifest.get_log_number();
+
+	// Try to set it to a lower value (should not change)
+	let lower_log_number = 30;
+	let changeset2 = ManifestChangeSet {
+		log_number: Some(lower_log_number),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset2).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.get_log_number(), current_log_number, "log_number should not decrease");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.get_log_number(),
+		current_log_number,
+		"log_number should remain unchanged after revert"
+	);
+}
+
+#[test]
+fn test_revert_last_sequence() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let initial_last_sequence = manifest.get_last_sequence();
+
+	let table = create_test_table_with_seq_nums(1, 1, 100, Arc::clone(&opts))
+		.expect("Failed to create table");
+
+	let changeset = ManifestChangeSet {
+		new_tables: vec![(0, table)],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.get_last_sequence(), 100, "last_sequence should be updated");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.get_last_sequence(),
+		initial_last_sequence,
+		"last_sequence should be reverted"
+	);
+}
+
+#[test]
+fn test_revert_manifest_version() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let initial_version = manifest.manifest_format_version;
+	let new_version = 2;
+
+	let changeset = ManifestChangeSet {
+		manifest_format_version: Some(new_version),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(
+		manifest.manifest_format_version, new_version,
+		"manifest_format_version should be updated"
+	);
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.manifest_format_version, initial_version,
+		"manifest_format_version should be reverted"
+	);
+}
+
+#[test]
+fn test_revert_snapshots_added() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let initial_snapshot_count = manifest.snapshots.len();
+
+	let snapshot1 = SnapshotInfo {
+		seq_num: 10,
+		created_at: std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_nanos())
+			.unwrap_or(0),
+	};
+	let snapshot2 = SnapshotInfo {
+		seq_num: 20,
+		created_at: std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_nanos())
+			.unwrap_or(0),
+	};
+
+	let changeset = ManifestChangeSet {
+		new_snapshots: vec![snapshot1, snapshot2],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.snapshots.len(), initial_snapshot_count + 2, "Snapshots should be added");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.snapshots.len(),
+		initial_snapshot_count,
+		"Snapshots should be removed on revert"
+	);
+}
+
+#[test]
+fn test_revert_snapshots_deleted() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add snapshots first
+	let snapshot1 = SnapshotInfo {
+		seq_num: 10,
+		created_at: std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_nanos())
+			.unwrap_or(0),
+	};
+	let snapshot2 = SnapshotInfo {
+		seq_num: 20,
+		created_at: std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_nanos())
+			.unwrap_or(0),
+	};
+
+	let add_changeset = ManifestChangeSet {
+		new_snapshots: vec![snapshot1, snapshot2],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	let initial_snapshot_count = manifest.snapshots.len();
+
+	// Now delete one
+	let delete_changeset = ManifestChangeSet {
+		deleted_snapshots: std::collections::HashSet::from([10]),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&delete_changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.snapshots.len(), initial_snapshot_count - 1, "Snapshot should be deleted");
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(
+		manifest.snapshots.len(),
+		initial_snapshot_count,
+		"Snapshot should be restored on revert"
+	);
+	assert!(manifest.snapshots.iter().any(|s| s.seq_num == 10));
+}
+
+#[test]
+fn test_revert_multiple_tables_same_level() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+	let table3 = create_test_table_with_seq_nums(3, 21, 30, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+	let table4 = create_test_table_with_seq_nums(4, 31, 40, Arc::clone(&opts))
+		.expect("Failed to create table 4");
+
+	let changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (0, table2), (0, table3), (0, table4)],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 4);
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 0, "All tables should be removed");
+}
+
+#[test]
+fn test_revert_table_only_one_in_level() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let table = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table");
+
+	let add_changeset = ManifestChangeSet {
+		new_tables: vec![(1, table)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&add_changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), 1);
+
+	let delete_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(1, 1)]),
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&delete_changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), 0);
+
+	manifest.revert_changeset(rollback);
+
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), 1, "Single table should be restored");
+	assert_eq!(manifest.levels.get_levels()[1].tables[0].id, 1);
+}
+
+#[test]
+fn test_revert_idempotent() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let table = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table");
+
+	let changeset = ManifestChangeSet {
+		new_tables: vec![(0, table)],
+		..Default::default()
+	};
+
+	let rollback = manifest.apply_changeset(&changeset).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 1, "Table should be added");
+
+	// Revert once
+	manifest.revert_changeset(rollback);
+
+	let state_after_revert = manifest.levels.get_levels()[0].tables.len();
+
+	assert_eq!(state_after_revert, 0, "Table should be removed after revert");
+}
+
+#[test]
+fn test_apply_revert_apply_cycle() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+
+	// First apply
+	let changeset1 = ManifestChangeSet {
+		new_tables: vec![(0, table1)],
+		..Default::default()
+	};
+	let rollback1 = manifest.apply_changeset(&changeset1).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 1);
+
+	// Revert
+	manifest.revert_changeset(rollback1);
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 0);
+
+	// Apply again
+	let table1_again = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let changeset2 = ManifestChangeSet {
+		new_tables: vec![(0, table1_again), (0, table2)],
+		..Default::default()
+	};
+	let _rollback2 = manifest.apply_changeset(&changeset2).expect("Failed to apply changeset");
+
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 2);
+}
+
+#[test]
+fn test_revert_after_disk_write_failure_simulation() {
+	let mut opts = Options::default();
+	let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+	let repo_path = temp_dir.path().to_path_buf();
+	opts.path = repo_path;
+	opts.level_count = 3;
+	let opts = Arc::new(opts);
+
+	fs::create_dir_all(opts.sstable_dir()).expect("Failed to create sstables dir");
+	fs::create_dir_all(opts.manifest_dir()).expect("Failed to create manifest dir");
+
+	let mut manifest = LevelManifest::new(Arc::clone(&opts)).expect("Failed to create manifest");
+
+	// Add some initial tables
+	let table1 = create_test_table_with_seq_nums(1, 1, 10, Arc::clone(&opts))
+		.expect("Failed to create table 1");
+	let table2 = create_test_table_with_seq_nums(2, 11, 20, Arc::clone(&opts))
+		.expect("Failed to create table 2");
+
+	let initial_changeset = ManifestChangeSet {
+		new_tables: vec![(0, table1), (0, table2)],
+		..Default::default()
+	};
+	let _ = manifest.apply_changeset(&initial_changeset).expect("Failed to apply changeset");
+
+	// Capture state before the operation that will "fail"
+	let state_before = (
+		manifest.levels.get_levels()[0].tables.len(),
+		manifest.levels.get_levels()[1].tables.len(),
+		manifest.get_last_sequence(),
+		manifest.get_log_number(),
+		manifest.manifest_format_version,
+	);
+
+	// Simulate a compaction-like operation: delete old tables, add new table
+	let table3 = create_test_table_with_seq_nums(3, 21, 100, Arc::clone(&opts))
+		.expect("Failed to create table 3");
+
+	let compaction_changeset = ManifestChangeSet {
+		deleted_tables: std::collections::HashSet::from([(0, 1), (0, 2)]),
+		new_tables: vec![(1, table3)],
+		log_number: Some(50),
+		..Default::default()
+	};
+
+	// Apply changeset (simulating in-memory update)
+	let rollback =
+		manifest.apply_changeset(&compaction_changeset).expect("Failed to apply changeset");
+
+	// Verify in-memory state changed
+	assert_eq!(manifest.levels.get_levels()[0].tables.len(), 0);
+	assert_eq!(manifest.levels.get_levels()[1].tables.len(), 1);
+	assert_eq!(manifest.get_last_sequence(), 100);
+	assert_eq!(manifest.get_log_number(), 50);
+
+	// Simulate disk write failure - revert the changeset
+	manifest.revert_changeset(rollback);
+
+	// Verify state is restored to before the operation
+	assert_eq!(
+		manifest.levels.get_levels()[0].tables.len(),
+		state_before.0,
+		"L0 table count should be restored"
+	);
+	assert_eq!(
+		manifest.levels.get_levels()[1].tables.len(),
+		state_before.1,
+		"L1 table count should be restored"
+	);
+	assert_eq!(manifest.get_last_sequence(), state_before.2, "last_sequence should be restored");
+	assert_eq!(manifest.get_log_number(), state_before.3, "log_number should be restored");
+	assert_eq!(
+		manifest.manifest_format_version, state_before.4,
+		"manifest_format_version should be restored"
+	);
+
+	// Verify original tables are still present
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 1));
+	assert!(manifest.levels.get_levels()[0].tables.iter().any(|t| t.id == 2));
+	assert!(!manifest.levels.get_levels()[1].tables.iter().any(|t| t.id == 3));
+}


### PR DESCRIPTION
When the write to manifest fails, the in memory state of the manifest gets corrupted and is not in sync with that on disk. This PR fixes the issue