### PR TITLE
ci: apple & android targets for CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   build-test:
     strategy:
       matrix:
-        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin' ]
+        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin', 'aarch64-apple-ios', 'aarch64-apple-ios-sim', 'aarch64-apple-tvos', 'aarch64-apple-tvos-sim', 'aarch64-apple-visionos', 'aarch64-apple-visionos-sim', 'aarch64-apple-watchos', 'aarch64-apple-watchos-sim', 'aarch64-linux-android' ]
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
@@ -32,7 +32,24 @@ jobs:
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-
+          - target: aarch64-apple-ios
+            os: macos-latest
+          - target: aarch64-apple-ios-sim
+            os: macos-latest
+          - target: aarch64-apple-tvos
+            os: macos-latest
+          - target: aarch64-apple-tvos-sim
+            os: macos-latest
+          - target: aarch64-apple-visionos
+            os: macos-latest
+          - target: aarch64-apple-visionos-sim
+            os: macos-latest
+          - target: aarch64-apple-watchos
+            os: macos-latest
+          - target: aarch64-apple-watchos-sim
+            os: macos-latest
+          - target: aarch64-linux-android
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -92,7 +109,7 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           RUSTFLAGS="-A warnings --cfg getrandom_backend=\"wasm_js\"" cargo build --target wasm32-unknown-unknown
-  
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   build-test:
     strategy:
       matrix:
-        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin', 'aarch64-apple-ios', 'aarch64-apple-ios-sim', 'aarch64-apple-tvos', 'aarch64-apple-tvos-sim', 'aarch64-apple-visionos', 'aarch64-apple-visionos-sim', 'aarch64-apple-watchos', 'aarch64-apple-watchos-sim', 'aarch64-linux-android' ]
+        target: [ 'x86_64-unknown-linux-gnu', 'aarch64-unknown-linux-gnu', 'x86_64-pc-windows-msvc', 'x86_64-apple-darwin', 'aarch64-apple-darwin', 'aarch64-apple-ios', 'aarch64-apple-ios-sim', 'aarch64-linux-android' ]
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
@@ -35,18 +35,6 @@ jobs:
           - target: aarch64-apple-ios
             os: macos-latest
           - target: aarch64-apple-ios-sim
-            os: macos-latest
-          - target: aarch64-apple-tvos
-            os: macos-latest
-          - target: aarch64-apple-tvos-sim
-            os: macos-latest
-          - target: aarch64-apple-visionos
-            os: macos-latest
-          - target: aarch64-apple-visionos-sim
-            os: macos-latest
-          - target: aarch64-apple-watchos
-            os: macos-latest
-          - target: aarch64-apple-watchos-sim
             os: macos-latest
           - target: aarch64-linux-android
             os: ubuntu-latest
@@ -76,6 +64,33 @@ jobs:
         if: ${{ !contains(matrix.os, 'windows') }}
         # Skip tests on Windows as compaction tests and some file system operations are not supported
         run: make test
+
+  experimental-build:
+    runs-on: macos-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ 'aarch64-apple-tvos', 'aarch64-apple-tvos-sim', 'aarch64-apple-visionos', 'aarch64-apple-visionos-sim', 'aarch64-apple-watchos', 'aarch64-apple-watchos-sim' ]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.target }}
+          components: rustfmt, clippy
+          default: true
+
+      - name: Build
+        run: cargo +nightly build --target=${{ matrix.target }}
 
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #368 

Minor change to the CI matrix to ensure SurrealKV builds for Apple (iOS, watchOS, tvOS, visionOS) & Android platforms