### PR TITLE
Fix: First Commit Win guarantee may be broken under high concurrency

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -21,7 +21,10 @@ pub(crate) struct Batch {
 	pub(crate) entries: Vec<BatchEntry>,
 	pub(crate) valueptrs: Vec<Option<ValuePointer>>, /* Parallel array to entries, None for
 	                                                  * inline values */
-	pub(crate) starting_seq_num: u64, // Starting sequence number for this batch
+	// Starting sequence number for this batch
+	// Initial with start sequence number of a transaction for the write-write conflict validation,
+	// and update to log sequence number before WAL write.
+	pub(crate) starting_seq_num: u64,
 	pub(crate) size: u64,             // Total size of all records (not serialized)
 }
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -24,6 +24,10 @@ pub trait CommitEnv: Send + Sync + 'static {
 
 	// Check for background errors before committing
 	fn check_background_error(&self) -> Result<()>;
+
+	// Validates that no key in our write set was modified after we started.
+	// Only checks memtables - returns TransactionRetry if history insufficient.
+	fn validate_write_conflicts(&self, batch: &Batch) -> Result<()>;
 }
 
 // Lock-free commit queue entry
@@ -237,13 +241,29 @@ impl CommitPipeline {
 
 		let (commit_batch, complete_rx) = CommitBatch::new(batch.count());
 
-		// Phase 1: Assign sequence number and write to WAL (serialized)
-		let processed_batch = self.prepare(&mut batch, Arc::clone(&commit_batch), sync)?;
-
-		// Phase 2: Apply to memtable (concurrent)
+		// Atomically applying a batch of write operations to WAL and Memtable.
 		let apply_result = {
-			let env = Arc::clone(&self.env);
-			env.apply(&processed_batch)
+			let _guard = self.write_mutex.lock();
+
+			// Validate write-write conflict.
+			self.env.validate_write_conflicts(&batch)?;
+
+			let count = batch.count() as u64;
+			let seq_num = self.log_seq_num.fetch_add(count, Ordering::SeqCst);
+
+			// Set sequence numbers in commit batch
+			commit_batch.set_seq_num(seq_num);
+			// Update starting sequence number in batch
+			batch.set_starting_seq_num(seq_num);
+
+			// Enqueue operation (single producer)
+			self.pending.enqueue(Arc::clone(&commit_batch));
+
+			// Write to WAL and process VLog (serialized under lock)
+			let processed_batch = self.env.write(&mut batch, seq_num, sync)?;
+
+			// Apply batch to memtable
+			self.env.apply(&processed_batch)
 		};
 
 		// =========================================================================
@@ -295,31 +315,6 @@ impl CommitPipeline {
 
 		// Wait for completion
 		complete_rx.await.map_err(|_| Error::PipelineStall)?
-	}
-
-	fn prepare(
-		&self,
-		batch: &mut Batch,
-		commit_batch: Arc<CommitBatch>,
-		sync: bool,
-	) -> Result<Batch> {
-		// Assign sequence number atomically and write to WAL (serialized)
-		let _guard = self.write_mutex.lock();
-
-		let count = batch.count() as u64;
-		let seq_num = self.log_seq_num.fetch_add(count, Ordering::SeqCst);
-
-		// Set sequence numbers in batch and commit batch
-		commit_batch.set_seq_num(seq_num);
-		batch.set_starting_seq_num(seq_num);
-
-		// Enqueue operation (single producer)
-		self.pending.enqueue(commit_batch);
-
-		// Write to WAL and process VLog (serialized under lock)
-		let processed_batch = self.env.write(batch, seq_num, sync)?;
-
-		Ok(processed_batch)
 	}
 
 	fn publish(&self) {
@@ -434,6 +429,10 @@ mod tests {
 		}
 
 		fn check_background_error(&self) -> Result<()> {
+			Ok(())
+		}
+
+		fn validate_write_conflicts(&self, _batch: &Batch) -> Result<()> {
 			Ok(())
 		}
 	}
@@ -558,6 +557,10 @@ mod tests {
 		fn check_background_error(&self) -> Result<()> {
 			Ok(())
 		}
+
+		fn validate_write_conflicts(&self, _batch: &Batch) -> Result<()> {
+			Ok(())
+		}
 	}
 
 	#[test(tokio::test(flavor = "multi_thread"))]
@@ -637,6 +640,10 @@ mod tests {
 		fn check_background_error(&self) -> Result<()> {
 			Ok(())
 		}
+
+		fn validate_write_conflicts(&self, _batch: &Batch) -> Result<()> {
+			Ok(())
+		}
 	}
 
 	/// Minimal reproduction: all applies fail.
@@ -712,6 +719,10 @@ mod tests {
 		}
 
 		fn check_background_error(&self) -> Result<()> {
+			Ok(())
+		}
+
+		fn validate_write_conflicts(&self, _batch: &Batch) -> Result<()> {
 			Ok(())
 		}
 	}

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -1031,6 +1031,10 @@ impl CommitEnv for LsmCommitEnv {
 	fn check_background_error(&self) -> Result<()> {
 		self.core.error_handler.check_error()
 	}
+
+	fn validate_write_conflicts(&self, batch: &Batch) -> Result<()> {
+		self.core.check_keys_conflict(batch.entries.iter().map(|b| b.key.as_slice()), batch.starting_seq_num)
+	}
 }
 
 // ===== Core with Background Task Management =====

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -733,11 +733,8 @@ impl Transaction {
 			return Ok(());
 		}
 
-		// This checks if any key in our write set was modified after we started.
-		self.validate_write_conflicts()?;
-
 		// Create and prepare batch directly
-		let mut batch = Batch::new(0);
+		let mut batch = Batch::new(self.start_seq_num);
 
 		// Extract the vector of entries for the current transaction,
 		// respecting the insertion order recorded with Entry::seqno.
@@ -767,14 +764,6 @@ impl Transaction {
 		// Mark the transaction as closed
 		self.closed = true;
 		Ok(())
-	}
-
-	/// Validates that no key in our write set was modified after we started.
-	/// Only checks memtables - returns TransactionRetry if history insufficient.
-	fn validate_write_conflicts(&self) -> Result<()> {
-		self.core
-			.inner
-			.check_keys_conflict(self.write_set.keys().map(|k| k.as_slice()), self.start_seq_num)
 	}
 
 	pub fn rollback(&mut self) {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The first-committer-wins guarantee may be broken under high concurrency.
The root cause is that the write-write conflict check doesn't not operate under serialization manner.

## What does this change do?

1. move `validate_write_conflicts` method into `CommitEnv` trait.
2. use `batch.starting_seq_num` to store `visible_seq_num` for `validate_write_conflicts` initially, and will be updated to log sequence number before write to WAL
3. Operate validating write-write conflict, WAL writing, and memtable insertion under write_mutex lock

## What is your testing strategy?
Run tests in my local. All passed.

## Is this related to any issues?

https://github.com/surrealdb/surrealkv/issues/376

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)