### PR TITLE
fix(iter): correct range-iterator boundary handling on direction changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1024,6 +1024,48 @@ pub trait LSMIterator {
 	/// Check if positioned on valid entry.
 	fn valid(&self) -> bool;
 
+	/// Re-anchor to the first entry as a CONTINUATION of the traversal already in
+	/// progress, rather than as a fresh, user-initiated seek. See
+	/// [`reanchor_last`](Self::reanchor_last) for the full contract.
+	fn reanchor_first(&mut self) -> Result<bool> {
+		self.seek_first()
+	}
+
+	/// Re-anchor to the last entry as a CONTINUATION of the traversal already in
+	/// progress, rather than as a fresh, user-initiated seek.
+	///
+	/// A merge layer that owns two sub-cursors has to reposition the one it is not
+	/// currently emitting from when iteration reverses direction. If that cursor
+	/// has gone invalid, "reposition" means "anchor to your extreme entry" — but
+	/// it must NOT mean "start over", because the traversal is not starting over.
+	///
+	/// The distinction is invisible for an iterator whose only state is a
+	/// position: for those the default here, a plain `seek_first`/`seek_last`, is
+	/// exactly right. It matters for an iterator carrying budget or policy state
+	/// accumulated over the traversal — an entry limit, a quota, a deadline — where
+	/// a user-initiated seek legitimately resets that state and an internal
+	/// re-anchor legitimately must not. Such an implementation MUST override these
+	/// two methods to reposition while preserving what it has already spent;
+	/// otherwise the reverse pass silently runs on a refunded budget and yields
+	/// entries the policy had excluded. `HistoryIterator` is the one implementation
+	/// in-tree that needs the override.
+	///
+	/// Note also that `valid()` cannot be used to tell the two situations apart —
+	/// an iterator stopped by a policy and one that simply ran out of data both
+	/// report `false`, and an implementation may reach the former without ever
+	/// recording it. That is precisely why this is an operation on the iterator
+	/// rather than a predicate the caller branches on.
+	///
+	/// One latent case worth knowing about: `TransactionHistoryIterator` takes the
+	/// default even though it wraps a `HistoryIterator` that does not. Its own
+	/// `valid()` is `current_source != None`, which goes false exactly when the
+	/// inner history source is policy-stopped and the write set is spent, so if it
+	/// were ever nested as the `I` of another merge layer it would inherit the
+	/// default and forward a budget-resetting seek. Nothing nests it today.
+	fn reanchor_last(&mut self) -> Result<bool> {
+		self.seek_last()
+	}
+
 	/// Get current key (zero-copy). Caller must check valid() first.
 	///
 	/// Returns an `InternalKeyRef` which provides access to:

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -667,10 +667,20 @@ impl Skiplist {
 pub(crate) struct SkiplistIterator<'a> {
 	list: &'a Skiplist,
 	nd: *mut Node,
-	lower: Option<Vec<u8>>,   // Inclusive lower bound
-	upper: Option<Vec<u8>>,   // Exclusive upper bound
-	lower_node: *mut Node,    // Cached node at lower bound
-	upper_node: *mut Node,    // Cached node at upper bound
+	lower: Option<Vec<u8>>, // Inclusive lower bound
+	upper: Option<Vec<u8>>, // Exclusive upper bound
+	// `lower_node` / `upper_node` memoise the first node the cursor was ever
+	// found to sit outside the bounds on, so subsequent steps onto the same node
+	// can be rejected by pointer identity instead of a key comparison.
+	//
+	// They are deliberately sticky: skiplist nodes are immutable and never
+	// unlinked, and the bounds are fixed for the lifetime of the iterator, so
+	// "this node's key is < `lower`" / "this node's key is >= `upper`" are facts
+	// that stay true across re-seeks. What must NOT be assumed is that a cursor
+	// sitting on one of them is a dead end: `last()` has to *start* on an
+	// out-of-bounds node and walk back off it. See the note in `last()`.
+	lower_node: *mut Node, // Cached node known to be below the inclusive lower bound
+	upper_node: *mut Node, // Cached node known to be at or past the exclusive upper bound
 	encoded_key_buf: Vec<u8>, // Buffer for encoded key to return InternalKeyRef
 }
 
@@ -689,6 +699,18 @@ impl<'a> SkiplistIterator<'a> {
 	#[inline]
 	pub fn key_bytes(&self) -> &[u8] {
 		debug_assert!(self.is_valid());
+		self.node_key_bytes()
+	}
+
+	/// Key bytes of whatever node the cursor sits on, without `is_valid()`'s
+	/// in-bounds requirement.
+	///
+	/// Only for the internal bound walks, which legitimately inspect nodes that
+	/// are outside the iterator's range. The caller must guarantee `nd` is a real
+	/// node (neither sentinel, non-null).
+	#[inline]
+	fn node_key_bytes(&self) -> &[u8] {
+		debug_assert!(!self.nd.is_null() && self.nd != self.list.head && self.nd != self.list.tail);
 		unsafe { (*self.nd).get_key_bytes(&self.list.arena) }
 	}
 
@@ -752,10 +774,23 @@ impl<'a> SkiplistIterator<'a> {
 		if self.nd == self.list.head || self.nd == self.lower_node {
 			return;
 		}
-		// Check upper bound first - if entry is at or past upper, move backward
+		// Check upper bound first - if entry is at or past upper, move backward.
+		//
+		// This walk must NOT be guarded by `is_valid()`. `is_valid()` is false
+		// both for the list sentinels AND for a cursor parked on the memoised
+		// `upper_node`/`lower_node` — and `upper_node` is precisely the node this
+		// loop exists to step back off. Guarding on `is_valid()` made the loop
+		// body unreachable whenever a previous forward `advance()` had already
+		// memoised the list's physically last node as `upper_node`, leaving
+		// `last()` pinned on that out-of-range node and reporting the iterator
+		// invalid (the `seek_last()`-after-`next()`-ran-past-the-end bug).
+		//
+		// `lower_node` still terminates the walk below, because a node known to
+		// be below the inclusive lower bound means everything from here down is
+		// out of range.
 		if let Some(upper) = self.upper.as_deref() {
-			while self.is_valid() {
-				let key = self.key_bytes();
+			while self.nd != self.list.head && self.nd != self.list.tail && !self.nd.is_null() {
+				let key = self.node_key_bytes();
 				if (self.list.cmp)(upper, key) == Ordering::Greater {
 					// key < upper, so this entry is valid
 					break;

--- a/src/memtable/skiplist.rs
+++ b/src/memtable/skiplist.rs
@@ -676,9 +676,7 @@ pub(crate) struct SkiplistIterator<'a> {
 	// They are deliberately sticky: skiplist nodes are immutable and never
 	// unlinked, and the bounds are fixed for the lifetime of the iterator, so
 	// "this node's key is < `lower`" / "this node's key is >= `upper`" are facts
-	// that stay true across re-seeks. What must NOT be assumed is that a cursor
-	// sitting on one of them is a dead end: `last()` has to *start* on an
-	// out-of-bounds node and walk back off it. See the note in `last()`.
+	// that stay true across re-seeks.
 	lower_node: *mut Node, // Cached node known to be below the inclusive lower bound
 	upper_node: *mut Node, // Cached node known to be at or past the exclusive upper bound
 	encoded_key_buf: Vec<u8>, // Buffer for encoded key to return InternalKeyRef
@@ -776,18 +774,11 @@ impl<'a> SkiplistIterator<'a> {
 		}
 		// Check upper bound first - if entry is at or past upper, move backward.
 		//
-		// This walk must NOT be guarded by `is_valid()`. `is_valid()` is false
-		// both for the list sentinels AND for a cursor parked on the memoised
-		// `upper_node`/`lower_node` — and `upper_node` is precisely the node this
-		// loop exists to step back off. Guarding on `is_valid()` made the loop
-		// body unreachable whenever a previous forward `advance()` had already
-		// memoised the list's physically last node as `upper_node`, leaving
-		// `last()` pinned on that out-of-range node and reporting the iterator
-		// invalid (the `seek_last()`-after-`next()`-ran-past-the-end bug).
-		//
-		// `lower_node` still terminates the walk below, because a node known to
-		// be below the inclusive lower bound means everything from here down is
-		// out of range.
+		// This walk must not be guarded by `is_valid()`: that reports false for a
+		// cursor parked on `upper_node`, which is precisely the node the walk exists
+		// to step back off. `lower_node` still terminates it, because a node known to
+		// be below the inclusive lower bound means everything from here down is out
+		// of range.
 		if let Some(upper) = self.upper.as_deref() {
 			while self.nd != self.list.head && self.nd != self.list.tail && !self.nd.is_null() {
 				let key = self.node_key_bytes();

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1409,11 +1409,75 @@ impl<'a> HistoryIterator<'a> {
 		self.backward_buffer_index = None;
 	}
 
-	fn reset_all_state(&mut self) {
+	/// Everything `reset_all_state` clears EXCEPT the `limit` budget counter.
+	///
+	/// `limit_reached` is cleared here rather than preserved because it is a
+	/// derived flag: `skip_to_valid_forward` and `collect_user_key_backward`
+	/// re-raise it from `entries_returned` against `limit` on the way out.
+	fn reset_position_state(&mut self) {
 		self.reset_forward_state();
 		self.clear_backward_buffer();
-		self.entries_returned = 0;
 		self.limit_reached = false;
+	}
+
+	fn reset_all_state(&mut self) {
+		self.reset_position_state();
+		self.entries_returned = 0;
+	}
+
+	/// Shared body of `seek_first`/`seek_last` and of the `reanchor_*` methods a
+	/// merge layer uses to reposition this iterator mid-traversal.
+	///
+	/// `reset_budget` is the sole difference between the two: a seek the user
+	/// asked for restarts the `limit` budget, an internal re-anchor continues on
+	/// whatever is left of it.
+	fn anchor(&mut self, direction: MergeDirection, reset_budget: bool) -> Result<bool> {
+		self.direction = direction;
+		self.reset_position_state();
+		if reset_budget {
+			self.entries_returned = 0;
+		}
+
+		// NOTE: `initialized` is set inside each arm, AFTER the inner seek, to
+		// match the originals and `seek()` below. On the success path the
+		// placement is invisible, but hoisting it above the seek would leave the
+		// iterator `initialized` on a seek error, so a later `next()` would take
+		// the normal-iteration branch and report `Ok(false)` instead of retrying
+		// via `seek_first()`.
+		match direction {
+			MergeDirection::Forward => {
+				if self.ts_range.is_some() {
+					// Seek to (lower_bound or empty, ts_end) to skip entries above range
+					let ts = self.ts_range.map(|(_, end)| end).unwrap_or(u64::MAX);
+					let seek_key = InternalKey::new(
+						self.lower_bound.clone().unwrap_or_default(),
+						u64::MAX,
+						InternalKeyKind::Set,
+						ts,
+					);
+					self.inner.seek(&seek_key.encode())?;
+				} else if let Some(ref lower) = self.lower_bound {
+					let seek_key =
+						InternalKey::new(lower.clone(), u64::MAX, InternalKeyKind::Set, u64::MAX);
+					self.inner.seek(&seek_key.encode())?;
+				} else {
+					self.inner.seek_first()?;
+				}
+				self.initialized = true;
+				self.skip_to_valid_forward()
+			}
+			MergeDirection::Backward => {
+				self.inner.seek_last()?;
+				self.initialized = true;
+				self.collect_user_key_backward()
+			}
+		}
+	}
+
+	/// Reposition to the extreme entry in `direction` without refunding the
+	/// `limit` budget already spent. See `LSMIterator::reanchor_last`.
+	fn reanchor(&mut self, direction: MergeDirection) -> Result<bool> {
+		self.anchor(direction, false)
 	}
 
 	// --- Inner iterator helpers ---
@@ -1866,38 +1930,11 @@ impl LSMIterator for HistoryIterator<'_> {
 	}
 
 	fn seek_first(&mut self) -> Result<bool> {
-		self.direction = MergeDirection::Forward;
-		self.reset_all_state();
-
-		if self.ts_range.is_some() {
-			// Seek to (lower_bound or empty, ts_end) to skip entries above range
-			let ts = self.ts_range.map(|(_, end)| end).unwrap_or(u64::MAX);
-			let seek_key = InternalKey::new(
-				self.lower_bound.clone().unwrap_or_default(),
-				u64::MAX,
-				InternalKeyKind::Set,
-				ts,
-			);
-			self.inner.seek(&seek_key.encode())?;
-		} else if let Some(ref lower) = self.lower_bound {
-			let seek_key =
-				InternalKey::new(lower.clone(), u64::MAX, InternalKeyKind::Set, u64::MAX);
-			self.inner.seek(&seek_key.encode())?;
-		} else {
-			self.inner.seek_first()?;
-		}
-
-		self.initialized = true;
-		self.skip_to_valid_forward()
+		self.anchor(MergeDirection::Forward, true)
 	}
 
 	fn seek_last(&mut self) -> Result<bool> {
-		self.direction = MergeDirection::Backward;
-		self.reset_all_state();
-
-		self.inner.seek_last()?;
-		self.initialized = true;
-		self.collect_user_key_backward()
+		self.anchor(MergeDirection::Backward, true)
 	}
 
 	fn next(&mut self) -> Result<bool> {
@@ -1945,6 +1982,27 @@ impl LSMIterator for HistoryIterator<'_> {
 			MergeDirection::Forward => self.inner_valid() && self.within_upper_bound(),
 			MergeDirection::Backward => self.has_buffered_entry(),
 		}
+	}
+
+	/// Overridden because `seek_first`/`seek_last` here begin with
+	/// `reset_all_state()`, which zeroes `entries_returned` — refunding the whole
+	/// `limit` budget. That is right for a seek the *user* asked for and wrong for
+	/// an internal re-anchor, which continues a traversal that has already spent
+	/// part of the budget.
+	///
+	/// Note this deliberately does NOT branch on `limit_reached`. That flag is
+	/// only ever set inside `skip_to_valid_forward`'s `while self.inner_valid()`
+	/// loop and inside `collect_user_key_backward` past its early returns, so when
+	/// the data runs dry at or before the limit the iterator goes invalid with the
+	/// flag still `false` and the budget already spent. Preserving the counter is
+	/// correct in both cases and needs no such test; the collect below re-derives
+	/// the flag from the remaining budget.
+	fn reanchor_first(&mut self) -> Result<bool> {
+		self.reanchor(MergeDirection::Forward)
+	}
+
+	fn reanchor_last(&mut self) -> Result<bool> {
+		self.reanchor(MergeDirection::Backward)
 	}
 
 	fn key(&self) -> InternalKeyRef<'_> {

--- a/src/test/iterator_semantics_tests.rs
+++ b/src/test/iterator_semantics_tests.rs
@@ -1,0 +1,311 @@
+use tempfile::TempDir;
+use test_log::test;
+
+use crate::lsm::Tree;
+use crate::{LSMIterator, TreeBuilder};
+
+fn create_store() -> (Tree, TempDir) {
+	let temp_dir = TempDir::new().unwrap();
+	let tree = TreeBuilder::new().with_path(temp_dir.path().to_path_buf()).build().unwrap();
+	(tree, temp_dir)
+}
+
+/// After stepping forward, `prev()` must move to the key immediately preceding
+/// the CURRENT POSITION in sorted order — not back to the previously returned
+/// key. This is the RocksDB convention.
+#[test(tokio::test)]
+async fn prev_after_next_yields_preceding_key() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	for k in ["a", "b", "c", "d"] {
+		txn.set(k.as_bytes(), b"v".as_ref()).unwrap();
+	}
+	txn.commit().await.unwrap();
+
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range("a", "z").unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"a");
+	assert!(iter.next().unwrap());
+	assert_eq!(iter.key().user_key(), b"b");
+	assert!(iter.next().unwrap());
+	assert_eq!(iter.key().user_key(), b"c");
+
+	assert!(iter.prev().unwrap());
+	assert_eq!(iter.key().user_key(), b"b", "prev() must yield the key preceding the cursor");
+}
+
+/// Direction switching across tombstones. This is the shape of bug #380
+/// (stack overflow on backward iteration over tombstoned keys).
+#[test(tokio::test)]
+async fn direction_switch_across_tombstones() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	for k in ["a", "b", "c", "d", "e"] {
+		txn.set(k.as_bytes(), b"v".as_ref()).unwrap();
+	}
+	txn.commit().await.unwrap();
+
+	let mut txn = tree.begin().unwrap();
+	for k in ["b", "c", "d"] {
+		txn.delete(k.as_bytes()).unwrap();
+	}
+	txn.commit().await.unwrap();
+
+	// Visible keys are now exactly ["a", "e"].
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range("a", "z").unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"a");
+	assert!(iter.next().unwrap());
+	assert_eq!(iter.key().user_key(), b"e");
+	assert!(iter.prev().unwrap());
+	assert_eq!(iter.key().user_key(), b"a");
+	assert!(!iter.prev().unwrap(), "prev() from the first key must invalidate");
+	assert!(!iter.valid());
+}
+
+/// `seek_last` then walking backward must enumerate every visible key in
+/// reverse, and stepping past the start must invalidate rather than wrap.
+#[test(tokio::test)]
+async fn seek_last_walks_backward_to_exhaustion() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	for k in ["a", "b", "c"] {
+		txn.set(k.as_bytes(), b"v".as_ref()).unwrap();
+	}
+	txn.commit().await.unwrap();
+
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range("a", "z").unwrap();
+
+	assert!(iter.seek_last().unwrap());
+	let mut seen = Vec::new();
+	while iter.valid() {
+		seen.push(iter.key().user_key().to_vec());
+		iter.prev().unwrap();
+	}
+	assert_eq!(seen, vec![b"c".to_vec(), b"b".to_vec(), b"a".to_vec()]);
+}
+
+/// `range` is start-inclusive and end-exclusive.
+#[test(tokio::test)]
+async fn range_bounds_are_start_inclusive_end_exclusive() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	for k in ["a", "b", "c"] {
+		txn.set(k.as_bytes(), b"v".as_ref()).unwrap();
+	}
+	txn.commit().await.unwrap();
+
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range("a", "c").unwrap();
+
+	let mut seen = Vec::new();
+	iter.seek_first().unwrap();
+	while iter.valid() {
+		seen.push(iter.key().user_key().to_vec());
+		iter.next().unwrap();
+	}
+	assert_eq!(seen, vec![b"a".to_vec(), b"b".to_vec()]);
+}
+
+/// `seek_first` lands on the range's only visible key;
+/// `next()` correctly runs past it and invalidates the iterator; but
+/// `seek_last()`, called on that invalidated iterator, fails to reposition —
+/// it stays invalid instead of landing back on the one visible key. This is
+/// the #370-shaped bug: a direction switch after the iterator has been
+/// driven off one end does not recover.
+///
+/// Reproduction requires a committed key beyond the range's exclusive end
+/// (`k11` here, outside `[k00, k09)`): with only `k08` set, the bug does not
+/// reproduce. Value size is irrelevant (reproduces with tiny values too, not
+/// just the original counterexample's 2048-byte ones).
+///
+/// Root cause (fixed): `SkiplistIterator::last()` guarded its
+/// walk-back-from-`tail` loop with `is_valid()`, which is false for a cursor
+/// parked on the memoised `upper_node` sentinel — exactly the node the loop has
+/// to step back off. `k11` is what makes the list's physically last node be that
+/// sentinel.
+#[test(tokio::test)]
+async fn seek_last_recovers_after_next_runs_past_end() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k08", b"v").unwrap();
+	txn.set(b"k11", b"v").unwrap(); // outside [k00, k09) — required to reproduce
+	txn.commit().await.unwrap();
+
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range(b"k00".to_vec(), b"k09".to_vec()).unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"k08");
+
+	assert!(!iter.next().unwrap(), "next() past the last entry must invalidate");
+	assert!(!iter.valid());
+
+	assert!(iter.seek_last().unwrap(), "seek_last() must recover after next() ran past the end");
+	assert_eq!(iter.key().user_key(), b"k08");
+}
+
+/// Post-flush variant of `seek_last_recovers_after_next_runs_past_end`. The
+/// memtable-path repro above is a skiplist-iterator defect (a sticky
+/// out-of-bounds node sentinel poisoning `SkiplistIterator::last`'s backward
+/// walk); the root-cause investigation explicitly did NOT determine whether the
+/// SSTable / B+tree iterators share it. Forcing a flush before reading takes the
+/// memtable out of the picture entirely and answers that. It passed even before
+/// the skiplist fix — the SSTable path re-seeks from scratch and caches no
+/// out-of-bounds sentinel — so it stands as a guard, not a repro.
+#[test(tokio::test)]
+async fn seek_last_recovers_after_next_runs_past_end_post_flush() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k08", b"v").unwrap();
+	txn.set(b"k11", b"v").unwrap(); // outside [k00, k09)
+	txn.commit().await.unwrap();
+	tree.flush().unwrap(); // data now lives in an SST, not the memtable
+
+	let txn = tree.begin().unwrap();
+	let mut iter = txn.range(b"k00".to_vec(), b"k09".to_vec()).unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"k08");
+
+	assert!(!iter.next().unwrap(), "next() past the last entry must invalidate");
+	assert!(!iter.valid());
+
+	assert!(iter.seek_last().unwrap(), "seek_last() must recover after next() ran past the end");
+	assert_eq!(iter.key().user_key(), b"k08");
+}
+
+/// Symptom D of the write-set direction-switch defect: with the current entry
+/// coming from the WRITE-SET and the snapshot iterator exhausted-forward, the
+/// forward -> backward fixup used to reposition only the write-set cursor and
+/// never re-anchor the snapshot iterator, so the committed key behind the cursor
+/// became unreachable and `prev()` invalidated one step early.
+///
+/// Requires a MIX of committed and uncommitted data: the committed `k01` supplies
+/// the snapshot entry that gets lost, the uncommitted `k02` puts `current_source`
+/// on the write-set at the moment direction reverses.
+#[test(tokio::test)]
+async fn prev_recovers_committed_key_behind_uncommitted_key() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k01", b"v").unwrap();
+	txn.commit().await.unwrap();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k02", b"v").unwrap();
+	// (left uncommitted on purpose — k02 must come from the write-set)
+	let mut iter = txn.range(b"k00".to_vec(), b"k03".to_vec()).unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"k01"); // from the snapshot
+	assert!(iter.next().unwrap());
+	assert_eq!(iter.key().user_key(), b"k02"); // from the write-set
+
+	assert!(iter.prev().unwrap(), "prev() must step back onto the committed k01");
+	assert_eq!(iter.key().user_key(), b"k01");
+	assert!(!iter.prev().unwrap(), "prev() from the first key must invalidate");
+}
+
+/// This test's characterisation has been wrong twice before, both
+/// times by reading cause out of a repro's incidental details:
+///
+/// - first as a "direction switch" bug (`seek_first()` then a mid-walk `seek_last()`) — disproved,
+///   it reproduces with `seek_last()` as the FIRST positioning call;
+/// - then as a tombstone bug ("a `Delete` immediately preceding the range's last live key") — also
+///   disproved: swapping the `delete(b"k08")` for a plain `set(b"k08", ..)` reproduces identically.
+///   The tombstone's only role was to be the second write-set entry.
+///
+/// The ACTUAL trigger is write-set *cardinality*: two or more write-set entries
+/// in range with the cursor on the extreme one for the current direction, and an
+/// invalid snapshot iterator. That made the direction-change fixup's
+/// `!snapshot_iter.valid()` guard fire and teleport the write-set cursor back to
+/// index 0, which `advance_ws()` then walked straight back to where it started —
+/// so `next()` re-emitted `k09` instead of invalidating. An uncommitted
+/// transaction with no committed data makes the snapshot permanently invalid,
+/// which is why no commit and no memtable rotation are needed.
+#[test(tokio::test)]
+async fn next_invalidates_after_seek_last_on_multi_entry_write_set() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k08", b"v").unwrap(); // second entry is all that matters
+	txn.set(b"k09", b"v").unwrap();
+	let mut iter = txn.range(b"k00".to_vec(), b"k10".to_vec()).unwrap();
+
+	assert!(iter.seek_last().unwrap());
+	assert_eq!(iter.key().user_key(), b"k09");
+
+	assert!(!iter.next().unwrap(), "next() past the last entry must invalidate");
+	assert!(!iter.valid());
+}
+
+/// The original tombstone-shaped spelling of the test above, kept as distinct
+/// coverage rather than deleted. The tombstone is not the trigger (see that
+/// test's doc comment) and `seek_last()` alone does not touch it — that lands
+/// `ws_pos` on `k09`, the live entry. The trailing `prev()` is what walks the
+/// cursor back onto the tombstone and so actually drives `position_to_max`'s
+/// tombstone-skipping arm; without it this test routes through exactly the same
+/// code as its non-tombstone sibling.
+#[test(tokio::test)]
+async fn next_invalidates_after_seek_last_when_tombstone_precedes_last_key() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	// or soft_delete() — identical.
+	txn.delete(b"k08").unwrap();
+	txn.set(b"k09", b"v").unwrap();
+	let mut iter = txn.range(b"k00".to_vec(), b"k10".to_vec()).unwrap();
+
+	assert!(iter.seek_last().unwrap());
+	assert_eq!(iter.key().user_key(), b"k09");
+
+	assert!(!iter.next().unwrap(), "next() past the last entry must invalidate");
+	assert!(!iter.valid());
+
+	// Re-seek (an invalid iterator stays invalid until an explicit seek), then
+	// step back onto the tombstone: it must be skipped, not emitted, and with
+	// nothing live behind it the iterator must invalidate.
+	assert!(iter.seek_last().unwrap());
+	assert_eq!(iter.key().user_key(), b"k09");
+	assert!(!iter.prev().unwrap(), "the k08 tombstone must be skipped, not emitted");
+	assert!(!iter.valid());
+}
+
+/// The exact mirror of `next_invalidates_after_seek_last_on_multi_entry_write_set`:
+/// same defect, same `!snapshot_iter.valid()` guard, the forward -> backward copy
+/// of the block instead of the backward -> forward one. Discovered separately,
+/// which is why it is a separate test.
+///
+/// `seek_first()` lands on the range's first visible key; `prev()` used to
+/// teleport the write-set cursor to the LAST entry and then walk it back to index
+/// 0, re-emitting `k01` instead of invalidating. Needs 2+ write-set entries for
+/// the same reason as its mirror — at cardinality 1 the teleport is a no-op — and
+/// an uncommitted transaction so the snapshot iterator stays invalid.
+#[test(tokio::test)]
+async fn prev_invalidates_from_first_key_seek_first_uncommitted() {
+	let (tree, _tmp) = create_store();
+
+	let mut txn = tree.begin().unwrap();
+	txn.set(b"k01", b"v").unwrap();
+	txn.set(b"k02", b"v").unwrap();
+	// (transaction left uncommitted — read-your-own-writes only; required to
+	// reproduce, see the doc comment above)
+	let mut iter = txn.range(b"k00".to_vec(), b"k03".to_vec()).unwrap();
+
+	assert!(iter.seek_first().unwrap());
+	assert_eq!(iter.key().user_key(), b"k01");
+
+	assert!(!iter.prev().unwrap(), "prev() from the first key must invalidate");
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -25,6 +25,8 @@ pub mod crash_consistency_tests;
 #[cfg(test)]
 pub mod index_block_tests;
 #[cfg(test)]
+pub mod iterator_semantics_tests;
+#[cfg(test)]
 pub mod iterator_tests;
 #[cfg(test)]
 pub mod level_tests;

--- a/src/test/version_iterator_tests.rs
+++ b/src/test/version_iterator_tests.rs
@@ -1468,6 +1468,230 @@ async fn test_history_limit_backward() {
 	}
 }
 
+/// An entry limit must survive a forward -> backward direction switch taken while
+/// the merge cursor is on a WRITE-SET entry.
+///
+/// `HistoryIterator::valid()` reports `false` for two very different reasons: it
+/// ran out of entries, or it stopped early because `limit` was reached. Its
+/// `seek_first`/`seek_last` both begin with `reset_all_state()`, which clears
+/// `entries_returned`/`limit_reached` — correct for a user-initiated seek, but
+/// catastrophic if the merge layer issues one internally to re-anchor a cursor it
+/// believes is exhausted. That would disarm the limit and resurrect versions the
+/// limit had excluded.
+///
+/// `test_history_limit_backward` above cannot catch this: it uses committed data
+/// only, so `current_source` is never `WriteSet` and the direction switch never
+/// has to re-anchor the history iterator. The uncommitted keys here are what put
+/// the cursor on the write set at the moment direction reverses.
+///
+/// TWO uncommitted keys, so the merge stays valid after the reversal and walks
+/// back across `kb` while the history source has to stay silent. With only one,
+/// the reversal invalidates the merge immediately and any follow-up assertion is
+/// vacuous — `prev()` early-returns on an already-invalid iterator and never
+/// reaches the re-anchor at all.
+#[test(tokio::test)]
+async fn history_limit_survives_direction_switch_from_write_set() {
+	for with_index in [false, true] {
+		let (store, _temp_dir) = create_versioned_store(with_index);
+
+		for i in 1..=5 {
+			let mut tx = store.begin().unwrap();
+			tx.set_at(b"ka", format!("v{}", i).as_bytes(), i * 100).unwrap();
+			tx.commit().await.unwrap();
+		}
+		store.flush().unwrap();
+
+		{
+			let mut tx = store.begin().unwrap();
+			// Uncommitted: these are the entries the cursor sits on when it reverses.
+			tx.set_at(b"kb", b"wb", 600).unwrap();
+			tx.set_at(b"kc", b"wc", 700).unwrap();
+
+			let opts = HistoryOptions::new().with_limit(2);
+			let mut iter = tx.history_with_options(b"ka", b"kd", &opts).unwrap();
+
+			// Forward: two "ka" versions consume the limit, then both write-set
+			// entries are emitted from the other source.
+			let mut seen = Vec::new();
+			assert!(iter.seek_first().unwrap(), "with_index={with_index}");
+			seen.push((iter.key().user_key().to_vec(), iter.key().timestamp()));
+			for _ in 0..3 {
+				assert!(iter.next().unwrap(), "with_index={with_index}");
+				seen.push((iter.key().user_key().to_vec(), iter.key().timestamp()));
+			}
+
+			assert_eq!(
+				seen,
+				vec![
+					(b"ka".to_vec(), 500),
+					(b"ka".to_vec(), 400),
+					(b"kb".to_vec(), 600),
+					(b"kc".to_vec(), 700)
+				],
+				"with_index={with_index}: forward prefix"
+			);
+
+			// Reversing must not re-anchor (and thereby re-arm) the limit-stopped
+			// history iterator. The merge stays valid — it steps back onto the
+			// other write-set entry — but no "ka" version may reappear.
+			assert!(iter.prev().unwrap(), "with_index={with_index}: prev() must reach kb");
+			assert_eq!(
+				(iter.key().user_key().to_vec(), iter.key().timestamp()),
+				(b"kb".to_vec(), 600),
+				"with_index={with_index}: prev() must not resurrect versions the limit excluded"
+			);
+
+			// The limit must still be spent after a backward step, not silently
+			// disarmed: with the write set spent too, there is nothing left.
+			assert!(
+				!iter.prev().unwrap(),
+				"with_index={with_index}: the limit must stay armed across backward steps"
+			);
+			assert!(!iter.valid(), "with_index={with_index}");
+		}
+		store.close().await.unwrap();
+	}
+}
+
+/// The same defect one data-shape away: the budget is spent, but the DATA ran out
+/// at the same moment, so `limit_reached` was never set.
+///
+/// `limit_reached = true` is only ever assigned inside `skip_to_valid_forward`'s
+/// `while self.inner_valid()` loop (`src/snapshot.rs`) and inside
+/// `collect_user_key_backward` after its early returns. When the underlying data
+/// runs dry at or before the limit, the loop body never executes and the iterator
+/// goes invalid with `limit_reached == false` while `entries_returned` is already
+/// at the budget. Any re-anchor decision keyed off the FLAG therefore reads
+/// "exhausted", re-seeks, and — because the seek resets `entries_returned` — hands
+/// the reverse pass a fresh full `limit`.
+///
+/// Two committed versions against `with_limit(2)` is the minimal shape: forward
+/// yields exactly the budget and empties the source in the same step.
+#[test(tokio::test)]
+async fn history_limit_survives_direction_switch_when_data_exhausts_first() {
+	for with_index in [false, true] {
+		let (store, _temp_dir) = create_versioned_store(with_index);
+
+		for i in 1..=2 {
+			let mut tx = store.begin().unwrap();
+			tx.set_at(b"ka", format!("v{}", i).as_bytes(), i * 100).unwrap();
+			tx.commit().await.unwrap();
+		}
+		store.flush().unwrap();
+
+		{
+			let mut tx = store.begin().unwrap();
+			tx.set_at(b"kb", b"wb", 600).unwrap();
+			tx.set_at(b"kc", b"wc", 700).unwrap();
+
+			let opts = HistoryOptions::new().with_limit(2);
+			let mut iter = tx.history_with_options(b"ka", b"kd", &opts).unwrap();
+
+			let mut seen = Vec::new();
+			assert!(iter.seek_first().unwrap(), "with_index={with_index}");
+			seen.push((iter.key().user_key().to_vec(), iter.key().timestamp()));
+			for _ in 0..3 {
+				assert!(iter.next().unwrap(), "with_index={with_index}");
+				seen.push((iter.key().user_key().to_vec(), iter.key().timestamp()));
+			}
+
+			// Both "ka" versions exactly consume the budget AND empty the source.
+			assert_eq!(
+				seen,
+				vec![
+					(b"ka".to_vec(), 200),
+					(b"ka".to_vec(), 100),
+					(b"kb".to_vec(), 600),
+					(b"kc".to_vec(), 700)
+				],
+				"with_index={with_index}: forward prefix"
+			);
+
+			assert!(iter.prev().unwrap(), "with_index={with_index}: prev() must reach kb");
+			assert_eq!(
+				(iter.key().user_key().to_vec(), iter.key().timestamp()),
+				(b"kb".to_vec(), 600),
+				"with_index={with_index}: a spent budget must not be refunded by the re-anchor"
+			);
+
+			assert!(
+				!iter.prev().unwrap(),
+				"with_index={with_index}: the spent budget must stay spent"
+			);
+			assert!(!iter.valid(), "with_index={with_index}");
+		}
+		store.close().await.unwrap();
+	}
+}
+
+/// The partial-budget case, which is what makes `limit` a *budget* carried across
+/// the reversal rather than a flag that is either tripped or not.
+///
+/// Three committed versions against `with_limit(5)`: the forward pass spends 3 and
+/// the data runs out, so the reverse pass must be allowed to spend the remaining
+/// 2 — and no more. A fix that merely refused to re-anchor whenever the budget was
+/// spent would under-yield here (3 in total, forfeiting the remaining 2); the
+/// original defect refunds the budget and re-collects all three versions, yielding
+/// 6. Both are wrong; the total must be exactly the limit.
+///
+/// A re-anchor implementation that refunds the budget (the original defect) fails
+/// this test with:
+///
+/// ```text
+/// assertion `left == right` failed: with_index=false: forward + reverse must
+/// total exactly the limit, neither refunded (>5) nor forfeited (3)
+///   left: 6
+///  right: 5
+/// ```
+#[test(tokio::test)]
+async fn history_limit_reverse_pass_runs_on_the_remaining_budget() {
+	for with_index in [false, true] {
+		let (store, _temp_dir) = create_versioned_store(with_index);
+
+		for i in 1..=3 {
+			let mut tx = store.begin().unwrap();
+			tx.set_at(b"ka", format!("v{}", i).as_bytes(), i * 100).unwrap();
+			tx.commit().await.unwrap();
+		}
+		store.flush().unwrap();
+
+		{
+			let mut tx = store.begin().unwrap();
+			tx.set_at(b"kb", b"wb", 600).unwrap();
+			tx.set_at(b"kc", b"wc", 700).unwrap();
+
+			let opts = HistoryOptions::new().with_limit(5);
+			let mut iter = tx.history_with_options(b"ka", b"kd", &opts).unwrap();
+
+			// Forward is [ka@300, ka@200, ka@100, kb, kc]; stop ON kc rather than
+			// past it, so the reversal happens from a valid position.
+			let mut history_entries = 0;
+			assert!(iter.seek_first().unwrap(), "with_index={with_index}");
+			for _ in 0..4 {
+				if iter.key().user_key() == b"ka" {
+					history_entries += 1;
+				}
+				assert!(iter.next().unwrap(), "with_index={with_index}");
+			}
+			assert_eq!(iter.key().user_key(), b"kc", "with_index={with_index}");
+			assert_eq!(history_entries, 3, "with_index={with_index}: forward spends 3 of 5");
+
+			// Reverse: re-anchoring must carry the 3 already spent, leaving 2.
+			while iter.prev().unwrap() {
+				if iter.key().user_key() == b"ka" {
+					history_entries += 1;
+				}
+			}
+			assert_eq!(
+				history_entries, 5,
+				"with_index={with_index}: forward + reverse must total exactly the limit, \
+				 neither refunded (>5) nor forfeited (3)"
+			);
+		}
+		store.close().await.unwrap();
+	}
+}
+
 #[test(tokio::test)]
 async fn test_history_limit_multiple_keys() {
 	for with_index in [false, true] {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -160,7 +160,13 @@ pub struct HistoryOptions {
 	/// Only versions within this range are returned.
 	/// Default: None (no timestamp filtering)
 	pub ts_range: Option<(u64, u64)>,
-	/// Optional limit on the total number of entries/versions to return.
+	/// Optional limit on the number of entries/versions to return per traversal.
+	///
+	/// The budget is spent as entries are yielded and is carried across a change
+	/// of direction, so a walk that runs forward and then back yields at most
+	/// `limit` entries in total. An explicit `seek_first`/`seek_last`/`seek`
+	/// starts a new traversal and restarts the budget.
+	///
 	/// Default: None (no limit)
 	pub limit: Option<usize>,
 }
@@ -183,7 +189,8 @@ impl HistoryOptions {
 		self
 	}
 
-	/// Set a limit on the total number of entries/versions to return.
+	/// Set a limit on the number of entries/versions to return per traversal.
+	/// See [`HistoryOptions::limit`].
 	pub fn with_limit(mut self, limit: usize) -> Self {
 		self.limit = Some(limit);
 		self
@@ -943,6 +950,111 @@ enum CurrentSource {
 	None,
 }
 
+/// Re-anchors the *non-current* sub-cursor when a write-set merge iterator
+/// reverses direction. Shared by `TransactionRangeIterator` and
+/// `TransactionHistoryIterator`, which are otherwise byte-identical here.
+///
+/// # Why the invalid case re-anchors rather than seeks
+///
+/// A plain `seek_first`/`seek_last` would be wrong for any `I` that carries state
+/// accumulated across the traversal, because a seek legitimately resets it —
+/// `HistoryIterator` refunds its whole `limit` budget. This is a continuation of a
+/// traversal in progress, not a new one, so it goes through
+/// [`LSMIterator::reanchor_first`]/[`reanchor_last`](LSMIterator::reanchor_last),
+/// whose contract is exactly "reposition without starting over". The default
+/// implementations are the plain seeks, so position-only iterators are unaffected.
+///
+/// Deciding this with a *predicate* instead — asking the iterator whether it is
+/// exhausted and skipping the re-anchor if not — does not work: an iterator can
+/// stop early without recording that it did, and it leaves the reverse pass no
+/// way to run on the remaining budget. Hence an operation, not a branch.
+///
+/// # The invariant this restores
+///
+/// After a positioning call, the merge iterator holds two sub-cursors and
+/// `current_source` names the one sitting on the emitted entry. The *other*
+/// cursor is, by construction, on the nearest entry at or beyond the emitted one
+/// in the current direction — strictly beyond it in the ordinary case, or exactly
+/// on it in the RYOW case where both sources hold the same key and the write-set
+/// copy won (`is_key_equal`) — or exhausted, meaning it has no such entry at all.
+///
+/// Reversing direction has to turn that into "the nearest entry strictly beyond
+/// the emitted one in the NEW direction", for the other cursor only; the current
+/// cursor is stepped afterwards by the caller's ordinary advance. Stepping the
+/// other cursor once handles both shapes: from strictly-beyond it lands on the
+/// neighbour on the far side of the emitted entry, and from on-the-emitted-entry
+/// it lands on that same neighbour. Three cases:
+///
+/// - the other cursor is positioned: step it one entry in the new direction;
+/// - the other cursor is invalid: either it ran out of entries, in which case every one of them
+///   lies on the new direction's side of the emitted entry, or it stopped early under a policy that
+///   is still in force. Both are served by re-anchoring it to its extreme entry — a still-binding
+///   policy re-applies itself there and the cursor simply stays invalid.
+///
+/// # What this replaced
+///
+/// ```ignore
+/// if !inner.valid() || !self.ws_valid() {
+///     self.seek_ws_first();   // seek_ws_last() in the prev() mirror
+/// } else if self.current_source == CurrentSource::Snapshot {
+///     self.advance_ws();
+/// } else {
+///     inner.next()?;
+/// }
+/// ```
+///
+/// That block had two independent faults, both live in three copies:
+///
+/// 1. **Teleport.** The guard fired on `!inner.valid()` — permanently true for an uncommitted
+///    transaction with no committed data — and then reset the *write-set* cursor to index 0 (or the
+///    last index). `advance_ws()` walked it straight back, so the iterator re-emitted the entry it
+///    was already on and failed to invalidate at the range's edge.
+/// 2. **Missing re-anchor.** When the exhausted cursor was `inner` and the current source was the
+///    write-set, `inner` was never repositioned at all — only the `current_source == Snapshot`
+///    branch ever touched it — so committed entries behind the cursor became unreachable and
+///    iteration invalidated one step early.
+///
+/// `CurrentSource::None` cannot reach here: `next()`/`prev()` return early on an
+/// invalid iterator. It is handled as a no-op so this stays total.
+fn reanchor_other_source<I: LSMIterator>(
+	inner: &mut I,
+	ws_pos: &mut Option<usize>,
+	ws_len: usize,
+	current_source: CurrentSource,
+	new_direction: MergeDirection,
+) -> Result<()> {
+	match current_source {
+		CurrentSource::None => {}
+		// The write-set is the other source.
+		CurrentSource::Snapshot => {
+			*ws_pos = match (*ws_pos, new_direction) {
+				(Some(pos), MergeDirection::Forward) => (pos + 1 < ws_len).then_some(pos + 1),
+				(Some(pos), MergeDirection::Backward) => pos.checked_sub(1),
+				(None, MergeDirection::Forward) => (ws_len > 0).then_some(0),
+				(None, MergeDirection::Backward) => ws_len.checked_sub(1),
+			};
+		}
+		// The snapshot / history iterator is the other source.
+		CurrentSource::WriteSet => match (inner.valid(), new_direction) {
+			(true, MergeDirection::Forward) => {
+				inner.next()?;
+			}
+			(true, MergeDirection::Backward) => {
+				inner.prev()?;
+			}
+			// Re-anchor, NOT seek: this continues a traversal already in progress,
+			// so any budget the cursor has spent must survive. See above.
+			(false, MergeDirection::Forward) => {
+				inner.reanchor_first()?;
+			}
+			(false, MergeDirection::Backward) => {
+				inner.reanchor_last()?;
+			}
+		},
+	}
+	Ok(())
+}
+
 /// An iterator that performs a merging scan over a transaction's snapshot and
 /// write set. Implements LSMIterator for zero-copy iteration.
 pub(crate) struct TransactionRangeIterator<'a> {
@@ -1257,18 +1369,26 @@ impl LSMIterator for TransactionRangeIterator<'_> {
 			return self.seek_first();
 		}
 
+		// Stepping off an already-invalid iterator is a no-op: an exhausted
+		// iterator stays exhausted until an explicit re-seek. Checked before the
+		// direction-change fixup so that fixup can never mutate the sub-cursors
+		// of an iterator that is about to report `false` anyway.
+		if !self.valid() {
+			return Ok(false);
+		}
+
 		// Direction change: backward → forward
 		if self.direction != MergeDirection::Forward {
 			self.direction = MergeDirection::Forward;
 			self.is_key_equal = false;
 
-			if !self.snapshot_iter.valid() || !self.ws_valid() {
-				self.seek_ws_first();
-			} else if self.current_source == CurrentSource::Snapshot {
-				self.advance_ws();
-			} else {
-				self.snapshot_iter.next()?;
-			}
+			reanchor_other_source(
+				&mut self.snapshot_iter,
+				&mut self.ws_pos,
+				self.write_set_entries.len(),
+				self.current_source,
+				MergeDirection::Forward,
+			)?;
 
 			// Check if now at equal keys
 			if self.snapshot_iter.valid()
@@ -1304,18 +1424,23 @@ impl LSMIterator for TransactionRangeIterator<'_> {
 			return self.seek_last();
 		}
 
+		// See the matching note in `next()`.
+		if !self.valid() {
+			return Ok(false);
+		}
+
 		// Direction change: forward → backward
 		if self.direction != MergeDirection::Backward {
 			self.direction = MergeDirection::Backward;
 			self.is_key_equal = false;
 
-			if !self.snapshot_iter.valid() || !self.ws_valid() {
-				self.seek_ws_last();
-			} else if self.current_source == CurrentSource::Snapshot {
-				self.advance_ws();
-			} else {
-				self.snapshot_iter.prev()?;
-			}
+			reanchor_other_source(
+				&mut self.snapshot_iter,
+				&mut self.ws_pos,
+				self.write_set_entries.len(),
+				self.current_source,
+				MergeDirection::Backward,
+			)?;
 
 			// Check if now at equal keys
 			if self.snapshot_iter.valid()
@@ -1953,18 +2078,23 @@ impl<'a> TransactionHistoryIterator<'a> {
 			return self.seek_first();
 		}
 
+		// See the matching note in `TransactionRangeIterator::next`.
+		if !self.valid() {
+			return Ok(false);
+		}
+
 		// Direction change: backward → forward
 		if self.direction != MergeDirection::Forward {
 			self.direction = MergeDirection::Forward;
 			self.is_key_equal = false;
 
-			if !self.inner.valid() || !self.ws_valid() {
-				self.seek_ws_first();
-			} else if self.current_source == CurrentSource::Snapshot {
-				self.advance_ws();
-			} else {
-				self.inner.next()?;
-			}
+			reanchor_other_source(
+				&mut self.inner,
+				&mut self.ws_pos,
+				self.write_set_entries.len(),
+				self.current_source,
+				MergeDirection::Forward,
+			)?;
 
 			// Check if now at equal (key, timestamp)
 			if self.inner.valid()
@@ -2005,18 +2135,23 @@ impl<'a> TransactionHistoryIterator<'a> {
 			return self.seek_last();
 		}
 
+		// See the matching note in `TransactionRangeIterator::next`.
+		if !self.valid() {
+			return Ok(false);
+		}
+
 		// Direction change: forward → backward
 		if self.direction != MergeDirection::Backward {
 			self.direction = MergeDirection::Backward;
 			self.is_key_equal = false;
 
-			if !self.inner.valid() || !self.ws_valid() {
-				self.seek_ws_last();
-			} else if self.current_source == CurrentSource::Snapshot {
-				self.advance_ws();
-			} else {
-				self.inner.prev()?;
-			}
+			reanchor_other_source(
+				&mut self.inner,
+				&mut self.ws_pos,
+				self.write_set_entries.len(),
+				self.current_source,
+				MergeDirection::Backward,
+			)?;
 
 			// Check if now at equal (key, timestamp)
 			if self.inner.valid()


### PR DESCRIPTION
Fixes #395.

Three defects, two root causes, plus one latent issue the de-duplication surfaced.

### 1. Sticky range sentinel in the skiplist iterator

`SkiplistIterator::last()` walked back from `tail` guarded by `is_valid()`, which is
false when the cursor sits on the memoised `upper_node` — exactly the node the
backward walk must step off. Re-guarded on "is a real node".

The sentinels stay sticky, which is sound and worth stating since it looks suspicious:
nodes are immutable and never unlinked, `lower`/`upper` are written once at iterator
construction with no re-bounding API, and the bump arena never frees or recycles an
offset. So "this node is out of range" is a permanent fact, not a snapshot in time.
`last()` was the only reader that had to *start* on a sentinel; the other bound checks
are guarded by `is_valid()` too, but cannot land on the opposing sentinel.

### 2. Direction-change fixup reset the write-set cursor

The fixup existed in four byte-identical copies (`TransactionRangeIterator::next`/
`prev`, `TransactionHistoryIterator::next`/`prev`) and reset the write-set cursor
whenever the other source was invalid — which, for an uncommitted transaction, is
always. Replaced all four with one shared `reanchor_other_source()`: step the
non-current cursor one entry in the new direction, and re-anchor it only if genuinely
exhausted. That fixes both the re-emission and the case where an exhausted snapshot
cursor was never repositioned, silently dropping a committed key.

### 3. Limit budget across a re-anchor

De-duplicating surfaced that `HistoryIterator::valid()` is false on `limit_reached`,
which is a policy stop rather than exhaustion, and that `seek_first`/`seek_last` clear
the counter via `reset_all_state()`.

A boolean predicate cannot express the right behaviour here: given only
`seek_first`/`seek_last` as re-anchor primitives, it can choose to refund the whole
budget or forfeit it, and both are wrong. So this adds
`LSMIterator::reanchor_first`/`reanchor_last`, defaulting to `seek_first`/`seek_last`
(unchanged for the eleven position-only implementors), with the contract "reposition
without starting over". `HistoryIterator` overrides them to reposition while preserving
`entries_returned`, so a reverse pass runs on the remaining budget and the existing
truncation applies it.

`seek_first`/`seek_last` and the re-anchors now share one body so the pair cannot
drift.

### Also

`next()`/`prev()` on an already-invalid iterator now stay invalid and mutate nothing.
This matches every other `LSMIterator` in the crate and RocksDB's contract, and closes
a path where the old fixup could mutate state and let an exhausted iterator report
valid again. Recovery is what `seek_first`/`seek_last`/`seek` are for.

### Tests

Every symptom has a regression test, each committed failing first:

- `src/test/iterator_semantics_tests.rs` (10 tests) — one per symptom, plus four that
  pin the surrounding semantics, plus a post-flush variant confirming the SSTable/B+tree
  path does **not** share defect 1 (it re-seeks from scratch).
- `src/test/version_iterator_tests.rs` (3 new) — limit preserved across a direction
  switch, limit preserved when the data exhausts before the limit is reached, and one
  that pins the exact arithmetic: 3 versions with `limit(5)` must total exactly 5,
  which distinguishes the correct behaviour from refunding (6) and forfeiting (3).

`cargo test --lib`: 1040 passed, 0 failed, 2 ignored (both pre-existing and unrelated).
`cargo clippy --all --all-targets` and `cargo +nightly fmt --all -- --check` clean.

### Note for reviewers

These were found by a model-based property test that compares the iterator against a
`BTreeMap` reference model over randomised bidirectional walks. That harness is not in
this PR — it is a larger piece of test infrastructure — but I am happy to open it
separately if it would be useful. It is what turned "backward scans sometimes look
wrong" into the four minimal reproductions above.
