### PR TITLE
Add get_for_update locked point reads to transactions

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -10,6 +10,7 @@ use crate::batch::Batch;
 use crate::error::{Error, Result};
 use crate::oracle::CommitOracle;
 use crate::stall::WriteStallController;
+use crate::Key;
 
 const MAX_CONCURRENT_COMMITS: usize = 8;
 const DEQUEUE_BITS: u32 = 32;
@@ -250,7 +251,13 @@ impl CommitPipeline {
 		self.oracle.reset_for_restore(max_seq);
 	}
 
-	pub(crate) async fn commit(&self, mut batch: Batch, sync: bool, start_seq: u64) -> Result<()> {
+	pub(crate) async fn commit(
+		&self,
+		mut batch: Batch,
+		sync: bool,
+		start_seq: u64,
+		read_set: &[Key],
+	) -> Result<()> {
 		if self.shutdown.load(Ordering::Acquire) {
 			return Err(Error::PipelineStall);
 		}
@@ -290,15 +297,26 @@ impl CommitPipeline {
 		//      enqueued. Roll back those entries (seq-match guard preserves concurrent
 		//      overwriters), drain the queue slot, release the lock, and return the error.
 		//
-		// Keys are derived from `batch.entries` (single source of truth).
-		// Duplicate keys within a batch (e.g. from savepoint history) are
-		// harmless: oracle.check/publish are idempotent on the same key.
+		// Write keys are derived from `batch.entries` (single source of
+		// truth); `read_set` contributes check-only keys that are validated
+		// but never published or written. Duplicate keys within a batch
+		// (e.g. from savepoint history) are harmless: oracle.check/publish
+		// are idempotent on the same key.
 		let (processed_batch, allocated_seq): (Batch, u64) = {
 			let _guard = self.write_mutex.lock();
 
-			// Validate against the oracle. No state has changed yet; on
-			// failure `?` simply returns the error to the caller.
-			self.oracle.check(batch.entries.iter().map(|e| e.key.as_slice()), start_seq)?;
+			// Validate against the oracle. The checked keys are the union of
+			// the batch's write keys and the caller's locked-read keys; only
+			// the write keys are published below. No state has changed yet;
+			// on failure `?` simply returns the error to the caller.
+			self.oracle.check(
+				batch
+					.entries
+					.iter()
+					.map(|e| e.key.as_slice())
+					.chain(read_set.iter().map(|k| k.as_slice())),
+				start_seq,
+			)?;
 
 			let count = batch.count() as u64;
 			let seq_num = self.log_seq_num.fetch_add(count, Ordering::SeqCst);
@@ -401,6 +419,28 @@ impl CommitPipeline {
 		}
 
 		complete_rx.await.map_err(|_| Error::PipelineStall)?
+	}
+
+	/// Validate `keys` against the commit oracle without allocating a seq,
+	/// publishing oracle entries, or writing anything.
+	///
+	/// This is the commit path for a transaction whose only commit-time
+	/// obligation is conflict validation of locked reads. The check runs
+	/// under `write_mutex`, which makes it atomic with respect to concurrent
+	/// committers: every commit that entered the critical section before us
+	/// has already published its oracle entries and is visible to this
+	/// check, and every commit that enters after us serializes after this
+	/// transaction's validation point.
+	pub(crate) fn check_conflicts(&self, keys: &[Key], start_seq: u64) -> Result<()> {
+		if self.shutdown.load(Ordering::Acquire) {
+			return Err(Error::PipelineStall);
+		}
+
+		// Check for background errors before proceeding
+		self.env.check_background_error()?;
+
+		let _guard = self.write_mutex.lock();
+		self.oracle.check(keys.iter().map(|k| k.as_slice()), start_seq)
 	}
 
 	#[cfg(test)]
@@ -538,7 +578,7 @@ mod tests {
 			.add_record(InternalKeyKind::Set, b"key1".to_vec(), Some(b"value1".to_vec()), 0)
 			.unwrap();
 
-		let result = pipeline.commit(batch, false, 0).await;
+		let result = pipeline.commit(batch, false, 0, &[]).await;
 		assert!(result.is_ok(), "Single commit failed: {result:?}");
 
 		let visible = pipeline.get_visible_seq_num();
@@ -566,7 +606,7 @@ mod tests {
 					i,
 				)
 				.unwrap();
-			let result = pipeline.commit(batch, false, 0).await;
+			let result = pipeline.commit(batch, false, 0, &[]).await;
 			assert!(result.is_ok(), "Sequential commit {i} failed: {result:?}");
 		}
 
@@ -593,7 +633,7 @@ mod tests {
 						i,
 					)
 					.unwrap();
-				pipeline.commit(batch, false, 0).await
+				pipeline.commit(batch, false, 0, &[]).await
 			});
 			handles.push(handle);
 		}
@@ -675,7 +715,7 @@ mod tests {
 						i,
 					)
 					.unwrap();
-				pipeline.commit(batch, false, 0).await
+				pipeline.commit(batch, false, 0, &[]).await
 			});
 			handles.push(handle);
 		}
@@ -760,7 +800,7 @@ mod tests {
 				)
 				.unwrap();
 
-			let result = pipeline.commit(batch, false, 0).await;
+			let result = pipeline.commit(batch, false, 0, &[]).await;
 			assert!(result.is_err(), "Expected error at iteration {i}");
 		}
 
@@ -839,7 +879,7 @@ mod tests {
 				)
 				.unwrap();
 
-			let result = pipeline.commit(batch, false, 0).await;
+			let result = pipeline.commit(batch, false, 0, &[]).await;
 
 			if i < fail_count {
 				assert!(result.is_err(), "Expected error at iteration {i}");
@@ -871,7 +911,7 @@ mod tests {
 		// allocated seq, then rolled back inside `commit()` on the apply error.
 		let mut batch = Batch::new(0);
 		batch.add_record(InternalKeyKind::Set, b"K".to_vec(), Some(b"v1".to_vec()), 0).unwrap();
-		let r1 = pipeline.commit(batch, false, 0).await;
+		let r1 = pipeline.commit(batch, false, 0, &[]).await;
 		assert!(r1.is_err(), "expected first apply to fail, got {r1:?}");
 		assert_eq!(pipeline.oracle().len(), 0, "rollback should have removed the entry");
 
@@ -880,7 +920,7 @@ mod tests {
 		// the oracle is empty so this MUST succeed — no ghost conflict.
 		let mut batch = Batch::new(0);
 		batch.add_record(InternalKeyKind::Set, b"K".to_vec(), Some(b"v2".to_vec()), 0).unwrap();
-		let r2 = pipeline.commit(batch, false, 0).await;
+		let r2 = pipeline.commit(batch, false, 0, &[]).await;
 		assert!(r2.is_ok(), "second commit on K should succeed (no ghost), got {r2:?}");
 
 		pipeline.shutdown();
@@ -948,7 +988,7 @@ mod tests {
 					0,
 				)
 				.unwrap();
-			let r = pipeline.commit(batch, false, 0).await;
+			let r = pipeline.commit(batch, false, 0, &[]).await;
 			assert!(r.is_ok(), "iter {i}: commit must succeed, got {r:?}");
 		}
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -265,8 +265,13 @@ impl CommitPipeline {
 		// Check for background errors before proceeding
 		self.env.check_background_error()?;
 
+		// An empty batch persists nothing, but any locked-read keys must
+		// still be validated before the commit can report success.
 		if batch.is_empty() {
-			return Ok(());
+			if read_set.is_empty() {
+				return Ok(());
+			}
+			return self.check_conflicts(read_set, start_seq);
 		}
 
 		// Check write stall BEFORE acquiring any locks.
@@ -586,6 +591,37 @@ mod tests {
 			visible, 1,
 			"Expected visible=1 after one commit with count=1 (highest seq num used)"
 		);
+
+		pipeline.shutdown();
+	}
+
+	#[test(tokio::test)]
+	async fn test_empty_batch_validates_read_set() {
+		let pipeline =
+			CommitPipeline::new(Arc::new(MockEnv), test_visible_seq_num(), test_write_stall());
+
+		// Publish a write to the key so it carries a commit seq in the oracle.
+		let mut batch = Batch::new(0);
+		batch.add_record(InternalKeyKind::Set, b"key1".to_vec(), Some(b"v1".to_vec()), 0).unwrap();
+		pipeline.commit(batch, false, 0, &[]).await.unwrap();
+
+		// An empty batch with a conflicting locked-read key must fail: the
+		// key was written after the caller's start seq.
+		let result = pipeline.commit(Batch::new(0), false, 0, &[b"key1".to_vec()]).await;
+		assert!(
+			matches!(result, Err(Error::TransactionWriteConflict)),
+			"Expected TransactionWriteConflict, got: {result:?}"
+		);
+
+		// The same locked-read key validates cleanly against a start seq at
+		// or after the write's commit seq.
+		let start_seq = pipeline.get_visible_seq_num();
+		let result = pipeline.commit(Batch::new(0), false, start_seq, &[b"key1".to_vec()]).await;
+		assert!(result.is_ok(), "Expected clean validation, got: {result:?}");
+
+		// An empty batch with no locked reads is a no-op.
+		let result = pipeline.commit(Batch::new(0), false, 0, &[]).await;
+		assert!(result.is_ok(), "Expected no-op commit, got: {result:?}");
 
 		pipeline.shutdown();
 	}

--- a/src/lsm.rs
+++ b/src/lsm.rs
@@ -29,6 +29,7 @@ use crate::{
 	Comparator,
 	Error,
 	FilterPolicy,
+	Key,
 	LSMIterator,
 	Options,
 	TimestampComparator,
@@ -1287,12 +1288,27 @@ impl Core {
 		Ok(core)
 	}
 
-	pub(crate) async fn commit(&self, batch: Batch, sync: bool, start_seq: u64) -> Result<()> {
+	pub(crate) async fn commit(
+		&self,
+		batch: Batch,
+		sync: bool,
+		start_seq: u64,
+		read_set: &[Key],
+	) -> Result<()> {
 		// Commit the batch using the commit pipeline. `start_seq` is the
 		// transaction's snapshot seq (used by the oracle's write-write
 		// conflict check). The write keys are derived from `batch.entries`
-		// inside the pipeline — no duplicated parallel array.
-		self.commit_pipeline.commit(batch, sync, start_seq).await
+		// inside the pipeline — no duplicated parallel array. `read_set`
+		// carries locked-read keys that join the conflict check without
+		// being written.
+		self.commit_pipeline.commit(batch, sync, start_seq, read_set).await
+	}
+
+	pub(crate) fn check_conflicts(&self, keys: &[Key], start_seq: u64) -> Result<()> {
+		// Validate locked-read keys against the commit oracle without
+		// writing anything. Used by transactions whose commit carries only
+		// locked reads.
+		self.commit_pipeline.check_conflicts(keys, start_seq)
 	}
 
 	pub(crate) fn seq_num(&self) -> u64 {

--- a/src/test/oracle_tests.rs
+++ b/src/test/oracle_tests.rs
@@ -114,7 +114,8 @@ async fn test_no_false_aborts_disjoint_keys() {
 }
 
 /// SI allows write-skew: txn1 reads X writes Y; txn2 reads X writes Z.
-/// Both must commit successfully because we do not track reads.
+/// Both must commit successfully because plain reads are not tracked
+/// (only `get_for_update` registers keys for validation).
 /// This confirms the design did not accidentally drift toward serializability.
 #[test(tokio::test)]
 async fn test_si_write_skew_still_allowed() {
@@ -436,5 +437,46 @@ async fn test_gc_oldest_active_monotonic() {
 		let mut t = store.begin().unwrap();
 		t.set(format!("mono_{i}").as_bytes(), b"v").unwrap();
 		t.commit().await.unwrap();
+	}
+}
+
+/// A check-only committer (locked read, no writes) racing a writer of the
+/// same key. The reader's commit validates under `write_mutex`, so it
+/// either serializes before the writer's publish (both commit) or after it
+/// (the reader gets `TransactionWriteConflict`). The writer must always
+/// commit; no other error variant is acceptable on either side.
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_locked_read_check_only_races_writer() {
+	let (store, _td) = create_store();
+	let store = Arc::new(store);
+
+	const ITERS: usize = 200;
+	for i in 0..ITERS {
+		let key = format!("locked_key_{i}").into_bytes();
+
+		let store1 = Arc::clone(&store);
+		let store2 = Arc::clone(&store);
+		let k1 = key.clone();
+		let k2 = key.clone();
+
+		let reader = tokio::spawn(async move {
+			let mut t = store1.begin().unwrap();
+			t.get_for_update(&k1).unwrap();
+			t.commit().await
+		});
+		let writer = tokio::spawn(async move {
+			let mut t = store2.begin().unwrap();
+			t.set(&k2, b"v").unwrap();
+			t.commit().await
+		});
+
+		let r = reader.await.unwrap();
+		let w = writer.await.unwrap();
+
+		assert!(w.is_ok(), "iteration {i}: writer must commit: {w:?}");
+		assert!(
+			r.is_ok() || matches!(r, Err(Error::TransactionWriteConflict)),
+			"iteration {i}: unexpected reader result: {r:?}"
+		);
 	}
 }

--- a/src/test/transaction_tests.rs
+++ b/src/test/transaction_tests.rs
@@ -1790,6 +1790,72 @@ mod get_for_update_tests {
 		let mut wo = store.begin_with_mode(Mode::WriteOnly).unwrap();
 		assert!(matches!(wo.get_for_update(b"k1"), Err(Error::TransactionWriteOnly)));
 	}
+
+	#[test(tokio::test)]
+	async fn failed_check_only_commit_is_terminal() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// The conflicting commit closes the transaction; a retry must fail
+		// loudly rather than report an unvalidated success.
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionClosed)));
+	}
+
+	#[test(tokio::test)]
+	async fn failed_write_commit_is_terminal() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let other = Vec::from("k2");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+		txn1.set(&other, b"v1").unwrap();
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// The conflicting commit closes the transaction; a retry must fail
+		// loudly rather than report an unvalidated success.
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionClosed)));
+
+		// The failed commit persisted nothing.
+		let txn3 = store.begin().unwrap();
+		assert!(txn3.get(&other).unwrap().is_none());
+	}
+
+	#[test(tokio::test)]
+	async fn concurrent_lockers_of_same_key_both_commit() {
+		let (store, _) = create_store();
+
+		let shared = Vec::from("shared");
+
+		// A locked read publishes nothing, so it is invisible to the other
+		// transaction's conflict check: locking is snapshot validation, not
+		// mutual exclusion.
+		let mut txn1 = store.begin().unwrap();
+		let mut txn2 = store.begin().unwrap();
+
+		assert!(txn1.get_for_update(&shared).unwrap().is_none());
+		assert!(txn2.get_for_update(&shared).unwrap().is_none());
+
+		txn1.set(b"out1", b"a").unwrap();
+		txn2.set(b"out2", b"b").unwrap();
+
+		txn1.commit().await.unwrap();
+		txn2.commit().await.unwrap();
+	}
 }
 
 #[test(tokio::test)]

--- a/src/test/transaction_tests.rs
+++ b/src/test/transaction_tests.rs
@@ -1591,6 +1591,207 @@ mod savepoint_tests {
 	}
 }
 
+mod get_for_update_tests {
+	use test_log::test;
+
+	use super::*;
+
+	#[test(tokio::test)]
+	async fn conflict_when_locked_key_written_by_other_txn() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let other = Vec::from("k2");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+
+		// Another transaction commits a write to the locked key.
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// txn1 writes a different key; the locked read still conflicts.
+		txn1.set(&other, b"v1").unwrap();
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+	}
+
+	#[test(tokio::test)]
+	async fn no_conflict_when_other_txn_writes_unrelated_key() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let other = Vec::from("k2");
+		let unrelated = Vec::from("k3");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+
+		// Another transaction commits a write to a key txn1 never locked.
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&unrelated, b"v3").unwrap();
+		txn2.commit().await.unwrap();
+
+		txn1.set(&other, b"v1").unwrap();
+		txn1.commit().await.unwrap();
+	}
+
+	#[test(tokio::test)]
+	async fn locked_key_also_written_still_conflicts() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// The locked key is also written, so the write-set key alone
+		// carries the conflict.
+		txn1.set(&key, b"v1").unwrap();
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+	}
+
+	#[test(tokio::test)]
+	async fn check_only_commit_conflicts_on_locked_key() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+
+		// txn1 locks the key but writes nothing.
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+	}
+
+	#[test(tokio::test)]
+	async fn check_only_commit_succeeds_without_concurrent_writer() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let value = Vec::from("v1");
+
+		let mut txn = store.begin().unwrap();
+		txn.set(&key, &value).unwrap();
+		txn.commit().await.unwrap();
+
+		// A locked read with no writes and no concurrent writer commits fine.
+		let mut txn1 = store.begin().unwrap();
+		assert_eq!(&txn1.get_for_update(&key).unwrap().unwrap(), &value);
+		txn1.commit().await.unwrap();
+	}
+
+	#[test(tokio::test)]
+	async fn reads_match_get_including_ryow() {
+		let (store, _) = create_store();
+
+		let key1 = Vec::from("k1");
+		let key2 = Vec::from("k2");
+		let value1 = Vec::from("v1");
+		let value2 = Vec::from("v2");
+
+		let mut txn = store.begin().unwrap();
+		txn.set(&key1, &value1).unwrap();
+		txn.commit().await.unwrap();
+
+		let mut txn1 = store.begin().unwrap();
+
+		// Committed value.
+		assert_eq!(txn1.get(&key1).unwrap(), txn1.get_for_update(&key1).unwrap());
+		assert_eq!(&txn1.get_for_update(&key1).unwrap().unwrap(), &value1);
+
+		// Missing key.
+		assert!(txn1.get_for_update(&key2).unwrap().is_none());
+
+		// RYOW: a pending write is visible.
+		txn1.set(&key2, &value2).unwrap();
+		assert_eq!(&txn1.get_for_update(&key2).unwrap().unwrap(), &value2);
+
+		// RYOW: a pending delete reads as None.
+		txn1.delete(&key1).unwrap();
+		assert!(txn1.get_for_update(&key1).unwrap().is_none());
+	}
+
+	#[test(tokio::test)]
+	async fn plain_get_does_not_register_for_validation() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let other = Vec::from("k2");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get(&key).unwrap().is_none());
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// A plain get takes no lock, so txn1 commits fine.
+		txn1.set(&other, b"v1").unwrap();
+		txn1.commit().await.unwrap();
+	}
+
+	#[test(tokio::test)]
+	async fn savepoint_rollback_releases_locks_taken_after_savepoint() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+		let other = Vec::from("k2");
+
+		let mut txn1 = store.begin().unwrap();
+		txn1.set_savepoint().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+		txn1.rollback_to_savepoint().unwrap();
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		// The lock was rolled back with the savepoint, so no conflict.
+		txn1.set(&other, b"v1").unwrap();
+		txn1.commit().await.unwrap();
+	}
+
+	#[test(tokio::test)]
+	async fn savepoint_rollback_keeps_locks_taken_before_savepoint() {
+		let (store, _) = create_store();
+
+		let key = Vec::from("k1");
+
+		let mut txn1 = store.begin().unwrap();
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+		txn1.set_savepoint().unwrap();
+		// Re-locking after the savepoint must not downgrade the earlier lock.
+		assert!(txn1.get_for_update(&key).unwrap().is_none());
+		txn1.rollback_to_savepoint().unwrap();
+
+		let mut txn2 = store.begin().unwrap();
+		txn2.set(&key, b"v2").unwrap();
+		txn2.commit().await.unwrap();
+
+		assert!(matches!(txn1.commit().await, Err(Error::TransactionWriteConflict)));
+	}
+
+	#[test(tokio::test)]
+	async fn rejected_in_read_only_and_write_only_modes() {
+		let (store, _) = create_store();
+
+		let mut ro = store.begin_with_mode(Mode::ReadOnly).unwrap();
+		assert!(matches!(ro.get_for_update(b"k1"), Err(Error::TransactionReadOnly)));
+
+		let mut wo = store.begin_with_mode(Mode::WriteOnly).unwrap();
+		assert!(matches!(wo.get_for_update(b"k1"), Err(Error::TransactionWriteOnly)));
+	}
+}
+
 #[test(tokio::test)]
 async fn test_soft_delete_basic_functionality() {
 	let (store, _temp_dir) = create_store();

--- a/src/test/transaction_tests.rs
+++ b/src/test/transaction_tests.rs
@@ -1856,6 +1856,45 @@ mod get_for_update_tests {
 		txn1.commit().await.unwrap();
 		txn2.commit().await.unwrap();
 	}
+
+	#[test(tokio::test)]
+	async fn cancelled_commit_success_on_retry() {
+		let temp_dir = create_temp_directory();
+		let store = TreeBuilder::new()
+			.with_path(temp_dir.path().to_path_buf())
+			.with_memtable_stall_threshold(2)
+			.build()
+			.unwrap();
+		// Force commit to wait before writing.
+		{
+			let mut immutables = store.core.inner.immutable_memtables.write().unwrap();
+			immutables.add(1, 0, Arc::new(crate::memtable::MemTable::new(1024)));
+			immutables.add(2, 0, Arc::new(crate::memtable::MemTable::new(1024)));
+		}
+
+		let locked = Vec::from("locked");
+		let written = Vec::from("written");
+
+		let mut txn = store.begin().unwrap();
+		assert!(txn.get_for_update(&locked).unwrap().is_none());
+		txn.set(&written, b"value").unwrap();
+
+		let result = tokio::time::timeout(std::time::Duration::from_millis(20), txn.commit()).await;
+		assert!(result.is_err(), "the deliberately stalled commit should time out");
+
+		// A cancelled commit must close the transaction.
+		assert!(txn.read_set.is_empty(), "cancelled commit drained the locked reads");
+		assert!(txn.write_set.is_empty(), "cancelled commit drained the pending writes");
+		let post_cancel_read = txn.get(&locked);
+		let retry_result = txn.commit().await;
+		let reader = store.begin().unwrap();
+		assert!(reader.get(&written).unwrap().is_none(), "cancelled write unexpectedly persisted");
+		assert!(
+			matches!(&post_cancel_read, Err(Error::TransactionClosed))
+				&& matches!(&retry_result, Err(Error::TransactionClosed)),
+			"cancelled commit must close the transaction: post_cancel_read={post_cancel_read:?}, retry_result={retry_result:?}"
+		);
+	}
 }
 
 #[test(tokio::test)]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -215,6 +215,15 @@ pub struct Transaction {
 	/// savepoints and rollbacks.
 	pub(crate) write_set: BTreeMap<Key, Vec<Entry>>,
 
+	/// `read_set` holds the keys registered via [`get_for_update`] for
+	/// commit-time conflict validation, each mapped to the savepoint number
+	/// at which it was first registered. These keys join the write-set keys
+	/// in the oracle conflict check at commit but are never written to
+	/// storage.
+	///
+	/// [`get_for_update`]: Transaction::get_for_update
+	pub(crate) read_set: BTreeMap<Key, u32>,
+
 	/// `closed` indicates if the transaction is closed. A closed transaction
 	/// cannot make any more changes to the data.
 	closed: bool,
@@ -283,6 +292,7 @@ impl Transaction {
 			snapshot,
 			core,
 			write_set: BTreeMap::new(),
+			read_set: BTreeMap::new(),
 			durability,
 			closed: false,
 			start_seq_num,
@@ -411,6 +421,41 @@ impl Transaction {
 		K: IntoBytes,
 	{
 		self.get_with_options(key, &ReadOptions::default())
+	}
+
+	/// Gets a value for a key if it exists, and registers the key for
+	/// commit-time conflict validation.
+	///
+	/// Read semantics are identical to [`get`], including read-your-own-writes
+	/// from the write set. In addition, the key joins the oracle conflict
+	/// check at commit: if another transaction commits a write to the key
+	/// after this transaction started, the commit fails with
+	/// [`Error::TransactionWriteConflict`]. The locked read itself persists
+	/// nothing.
+	///
+	/// Requires a `ReadWrite` transaction: read-only transactions cannot run
+	/// commit-time validation, and write-only transactions cannot read.
+	///
+	/// [`get`]: Transaction::get
+	pub fn get_for_update<K>(&mut self, key: K) -> Result<Option<Value>>
+	where
+		K: IntoBytes,
+	{
+		// Commit-time validation requires a commit, which read-only
+		// transactions cannot perform.
+		if !self.mode.mutable() {
+			return Err(Error::TransactionReadOnly);
+		}
+
+		let key = key.into_bytes();
+		let value = self.get_with_options(key.as_slice(), &ReadOptions::default())?;
+
+		// Register the key for the commit-time oracle check. Keep the
+		// earliest savepoint number so a savepoint rollback only releases
+		// locks first acquired after the corresponding set_savepoint call.
+		self.read_set.entry(key).or_insert(self.savepoints);
+
+		Ok(value)
 	}
 
 	/// Gets a value for a key at a specific timestamp.
@@ -743,8 +788,13 @@ impl Transaction {
 			return Err(Error::TransactionReadOnly);
 		}
 
-		// If there are no pending writes, there's nothing to commit, so return early.
+		// If there are no pending writes, only the locked reads (if any) need
+		// commit-time validation; nothing is persisted.
 		if self.write_set.is_empty() {
+			if !self.read_set.is_empty() {
+				let read_set: Vec<Key> = std::mem::take(&mut self.read_set).into_keys().collect();
+				self.core.check_conflicts(&read_set, self.start_seq_num)?;
+			}
 			self.closed = true;
 			// Release the GC watermark slot promptly; otherwise it waits for Drop.
 			if let Some(mut g) = self.txn_guard.take() {
@@ -758,6 +808,14 @@ impl Transaction {
 		// seq allocation. The pipeline derives oracle keys from
 		// `batch.entries` itself, so we don't pre-collect a parallel vector.
 		let mut batch = Batch::new(0);
+
+		// Locked-read keys not shadowed by a write join the oracle conflict
+		// check alongside the batch keys; shadowed keys are already covered
+		// by the batch entries.
+		let read_set: Vec<Key> = std::mem::take(&mut self.read_set)
+			.into_keys()
+			.filter(|k| !self.write_set.contains_key(k))
+			.collect();
 
 		// Extract the vector of entries for the current transaction,
 		// respecting the insertion order recorded with Entry::seqno.
@@ -784,7 +842,7 @@ impl Transaction {
 		// seq alloc + oracle.publish + WAL atomically under `write_mutex`,
 		// then runs memtable apply OUTSIDE the lock.
 		let should_sync = self.durability == Durability::Immediate;
-		self.core.commit(batch, should_sync, self.start_seq_num).await?;
+		self.core.commit(batch, should_sync, self.start_seq_num, &read_set).await?;
 
 		// Mark the transaction as closed and release the watermark slot.
 		self.closed = true;
@@ -797,6 +855,7 @@ impl Transaction {
 	pub fn rollback(&mut self) {
 		self.closed = true;
 		self.write_set.clear();
+		self.read_set.clear();
 		self.snapshot.take();
 		self.savepoints = 0;
 		self.write_seqno = 0;
@@ -858,6 +917,10 @@ impl Transaction {
 
 		// Remove keys with no entries left after the rollback above.
 		self.write_set.retain(|_, entries| !entries.is_empty());
+
+		// Release locked reads first acquired since the last call to
+		// set_savepoint().
+		self.read_set.retain(|_, savepoint_no| *savepoint_no != self.savepoints);
 
 		// Decrement the latest savepoint number unless it's zero.
 		// Cannot undeflow due to the zero check above.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -806,17 +806,13 @@ impl Transaction {
 			return Err(Error::TransactionReadOnly);
 		}
 
-		let result = self.commit_inner().await;
-
-		// Close the transaction whether the attempt succeeded or failed:
-		// the write set and read set have been consumed, so leaving the
-		// transaction open would let a retried commit report success
-		// without validating or persisting anything. Release the GC
-		// watermark slot promptly; otherwise it waits for Drop.
+		// Close before awaiting so a cancelled commit cannot be retried.
 		self.closed = true;
-		if let Some(mut g) = self.txn_guard.take() {
-			g.release();
-		}
+
+		// Moving the guard here releases it even if commit is cancelled.
+		let txn_guard = self.txn_guard.take();
+		let result = self.commit_inner().await;
+		drop(txn_guard);
 
 		result
 	}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -433,6 +433,17 @@ impl Transaction {
 	/// [`Error::TransactionWriteConflict`]. The locked read itself persists
 	/// nothing.
 	///
+	/// The guarantee is snapshot validation, not mutual exclusion: commit
+	/// fails only if another transaction committed a *write* to the key
+	/// after this transaction's snapshot. A locked read publishes nothing,
+	/// so it is invisible to other transactions' conflict checks — two
+	/// transactions may lock the same key concurrently and, provided
+	/// neither commits a write to it, both commit successfully. Locked
+	/// reads therefore do not prevent write skew between transactions that
+	/// only read the contended key; callers that need concurrent lockers of
+	/// the same key to conflict with each other must write the key (for
+	/// example, by writing back the value that was read).
+	///
 	/// Requires a `ReadWrite` transaction: read-only transactions cannot run
 	/// commit-time validation, and write-only transactions cannot read.
 	///
@@ -776,7 +787,14 @@ impl Transaction {
 		Ok(())
 	}
 
-	/// Commits the transaction, by writing all pending entries to the store.
+	/// Commits the transaction, writing all pending entries to the store and
+	/// validating any locked reads against the commit oracle.
+	///
+	/// A commit attempt is terminal: on success and on failure alike the
+	/// transaction closes, and every subsequent operation on it returns
+	/// [`Error::TransactionClosed`]. The attempt consumes the pending write
+	/// and locked-read state, so a failed commit cannot be retried — begin a
+	/// new transaction instead.
 	pub async fn commit(&mut self) -> Result<()> {
 		// If the transaction is closed, return an error.
 		if self.closed {
@@ -788,19 +806,36 @@ impl Transaction {
 			return Err(Error::TransactionReadOnly);
 		}
 
+		let result = self.commit_inner().await;
+
+		// Close the transaction whether the attempt succeeded or failed:
+		// the write set and read set have been consumed, so leaving the
+		// transaction open would let a retried commit report success
+		// without validating or persisting anything. Release the GC
+		// watermark slot promptly; otherwise it waits for Drop.
+		self.closed = true;
+		if let Some(mut g) = self.txn_guard.take() {
+			g.release();
+		}
+
+		result
+	}
+
+	/// Performs the fallible portion of [`commit`]: batch construction,
+	/// oracle validation, and the pipeline write. The caller closes the
+	/// transaction and releases the watermark slot regardless of the
+	/// outcome.
+	///
+	/// [`commit`]: Transaction::commit
+	async fn commit_inner(&mut self) -> Result<()> {
 		// If there are no pending writes, only the locked reads (if any) need
 		// commit-time validation; nothing is persisted.
 		if self.write_set.is_empty() {
-			if !self.read_set.is_empty() {
-				let read_set: Vec<Key> = std::mem::take(&mut self.read_set).into_keys().collect();
-				self.core.check_conflicts(&read_set, self.start_seq_num)?;
+			if self.read_set.is_empty() {
+				return Ok(());
 			}
-			self.closed = true;
-			// Release the GC watermark slot promptly; otherwise it waits for Drop.
-			if let Some(mut g) = self.txn_guard.take() {
-				g.release();
-			}
-			return Ok(());
+			let read_set: Vec<Key> = std::mem::take(&mut self.read_set).into_keys().collect();
+			return self.core.check_conflicts(&read_set, self.start_seq_num);
 		}
 
 		// Create and prepare batch directly. `Batch::new(0)`: the
@@ -842,14 +877,7 @@ impl Transaction {
 		// seq alloc + oracle.publish + WAL atomically under `write_mutex`,
 		// then runs memtable apply OUTSIDE the lock.
 		let should_sync = self.durability == Durability::Immediate;
-		self.core.commit(batch, should_sync, self.start_seq_num, &read_set).await?;
-
-		// Mark the transaction as closed and release the watermark slot.
-		self.closed = true;
-		if let Some(mut g) = self.txn_guard.take() {
-			g.release();
-		}
-		Ok(())
+		self.core.commit(batch, should_sync, self.start_seq_num, &read_set).await
 	}
 
 	pub fn rollback(&mut self) {


### PR DESCRIPTION
## What

Adds `Transaction::get_for_update`: a locked point read with the same read semantics as `get` (read-your-own-writes included) that registers the key for commit-time conflict detection. A transaction that locked a key commits only if no other transaction committed a write to that key after its snapshot.

## How

- New `read_set: BTreeMap<Key, u32>` on `Transaction` (key → savepoint number at first registration), populated by `get_for_update`. Requires ReadWrite mode (`TransactionReadOnly` otherwise, since validation cannot run at commit).
- At commit, the keys passed to the oracle conflict check are the union of write-set keys and read-set keys; the write payload (publish/WAL/apply) remains exactly the write set — locked reads write nothing. Read-set keys shadowed by a write are dropped before the check since the write key covers them.
- A commit with an empty write set but non-empty read set runs a new `CommitPipeline::check_conflicts`: after the same shutdown and background-error gates as a normal commit, it acquires `write_mutex` and runs `oracle.check` under it — the same lock under which every normal commit runs check + seq-alloc + publish + WAL — so validation is atomic with respect to concurrent committers. It deliberately skips the write-stall gate and commit semaphore because it never enqueues, allocates no seq, and writes nothing.
- `rollback()` clears the read set; `rollback_to_savepoint()` retains entries by savepoint number, following the write-set pattern.
- Conflicts surface as the existing `TransactionWriteConflict` (same oracle mechanism, no new downstream mapping needed); `TransactionRetry` can surface from the same check exactly as for write commits.

## Tests

10 new transaction tests (conflict, control, locked-read-only conflict and clean commit, value semantics, plain-get non-registration, read-only rejection, savepoint interactions) plus an oracle concurrency test racing a check-only commit against a writer. Full suite passes.

## Motivation

Consumed by SurrealDB's `SELECT ... FOR UPDATE` (surrealdb PR #998) as this engine's conflict-registration primitive.
